### PR TITLE
Replacing double quotes with single quotes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -49,15 +49,15 @@ jobs:
         run: yarn build
 
       - name: Check Inputs
-        run: echo "Version - ${{inputs.version}}"
+        run: echo "Version - ${{github.event.inputs.version}}"
 
       - name: Update package.json version for alpha releases
-        if: ${{ contains(inputs.version, 'alpha') }}
-        run: jq '.version = "${{inputs.version}}"' ./package.json
+        if: ${{ contains(github.event.inputs.version, 'alpha') }}
+        run: jq '.version = "${{github.event.inputs.version}}"' ./package.json
 
       - name: Publish package
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.PLATFORM_SA_NPM_TOKEN }}
           access: public
-          tag: ${{ contains(github.event.inputs.tag, 'alpha') && 'alpha' || 'latest' }}
+          tag: ${{ contains(github.event.inputs.version, 'alpha') && 'alpha' || 'latest' }}


### PR DESCRIPTION
# Summary

Replacing double quotes with single quotes when calling the `contains` function.


# Why the changes

- The current workflow is [failing](https://github.com/immutable/imx-core-sdk/actions/runs/2356202048/workflow) because of the double quotes.
- We were reading the wrong input attribute.
