### PR TITLE
Generate Stark Keys From EthAddress and Signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `generateStarkWalletFromSignedMessage` function to generate stark keys from EthAddress and Signature
+
 ### Changed
 
 - Added `project_owner_address` property to collection objects returned from `GET` `/v1/collections` public API endpoints.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,7 @@ import {
 import { GetSignableBurnRequest } from '../workflows/types';
 
 export interface StarkWallet {
+  path: string;
   starkPublicKey: string;
   starkKeyPair: ec.KeyPair;
 }

--- a/src/utils/stark/stark-key.test.ts
+++ b/src/utils/stark/stark-key.test.ts
@@ -1,4 +1,8 @@
-import { getAccountPath, getKeyPairFromPath } from './stark-key';
+import {
+  getAccountPath,
+  getKeyPairFromPath,
+  generateStarkWalletFromSignedMessage,
+} from './stark-key';
 
 const layer = 'starkex';
 const application = 'starkdeployement';
@@ -14,6 +18,21 @@ describe('Key derivation', () => {
     const keyPair = getKeyPairFromPath(seed, path);
     expect(keyPair.getPrivate('hex')).toEqual(
       '06cf0a8bf113352eb863157a45c5e5567abb34f8d32cddafd2c22aa803f4892c',
+    );
+  });
+});
+
+describe('generateStarkWalletFromSignedMessage', () => {
+  const signature =
+  '0x6d1550458c7a9a1257d73adbcf0fabc12f4497e970d9fa62dd88bf7d9e12719148c96225c1402d8707fd061b1aae2222bdf13571dfc82b3aa9974039f247f2b81b';
+
+  it('should generate stark wallet correctly', async () => {
+    const { starkPublicKey } = await generateStarkWalletFromSignedMessage(
+      ethAddress,
+      signature,
+    );
+    expect(starkPublicKey).toEqual(
+      '0x035919acd61e97b3ecdc75ff8beed8d1803f7ea3cad2937926ae59cc3f8070d4',
     );
   });
 });

--- a/src/utils/stark/stark-key.ts
+++ b/src/utils/stark/stark-key.ts
@@ -93,16 +93,21 @@ export async function generateStarkWallet(
   signer: Signer,
 ): Promise<StarkWallet> {
   const ethAddress = (await signer.getAddress()).toLowerCase();
+  const signature = await signer.signMessage(DEFAULT_SIGNATURE_MESSAGE);
+  return generateStarkWalletFromSignedMessage(ethAddress, signature)
+}
+
+export async function generateStarkWalletFromSignedMessage(ethAddress: string, signature: string) : Promise<StarkWallet> {
   const path = getAccountPath(
     DEFAULT_ACCOUNT_LAYER,
     DEFAULT_ACCOUNT_APPLICATION,
     ethAddress,
     DEFAULT_ACCOUNT_INDEX,
   );
-  const signature = await signer.signMessage(DEFAULT_SIGNATURE_MESSAGE);
   const keyPair = getKeyPairFromPath(splitSignature(signature).s, path);
   const starkPublic = getStarkPublicKey(keyPair);
   return {
+    path,
     starkPublicKey: encUtils.sanitizeHex(getXCoordinate(starkPublic)),
     starkKeyPair: keyPair,
   };


### PR DESCRIPTION
# Summary
This PR generate the Stark Keys from **ethAddress** and **signature** .

# Why the changes

* We need to change it in core-sdk because the starkkey generation is on Core-SDK.
* The existed function used signer to generate the starkKey. but signer doesn't existed in the L2Wallet(iframe)(it only exists outside of the iframe). in the L2Wallet we have only **EthAddress** and **SignedMessage**. so that's why we need to add this function from the core-sdk
* Returns the **path** as well, that is because we want to store it in the localStorage, and the path would be the key if I align to the current localstorage structure like the following screenshot:
![Screen Shot 2022-06-20 at 7 33 25 PM](https://user-images.githubusercontent.com/3668156/174548872-b59e97e1-7123-4c76-91a3-72141f603822.png)



# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

It is the first PR from Wallet Team, so we don't know about the Process like:
* Should we bump the version
* Where should we update the changelog
* How to release the package. 
