### PR TITLE
Add function to enable create trade workflow with l2signer [wt-423]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added `BaseSigner`, a default implementation of the Stark L2Signer interface
+- Added `createTradeWithSigner` function to enable creating trade workflow with l2signer
+
+### Changed
+- mark `createTrade` as deprecated 
+
 ## [0.3.1] - 2022-07-01
 
 ### Fixed

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './crypto/constants';
 export * from './stark/points';
 export * from './stark/stark-curve';
 export * from './stark/stark-key';
+export * from './stark/base-signer';

--- a/src/utils/stark/base-signer.ts
+++ b/src/utils/stark/base-signer.ts
@@ -1,8 +1,8 @@
+import BN from 'bn.js';
 import { ec } from 'elliptic';
 import * as encUtils from 'enc-utils';
 import { L2Signer } from '../../types';
-import { fixMessage } from './stark-curve';
-
+import { Errors } from '../../workflows/errors';
 
 export class BaseSigner implements L2Signer {
   constructor(private keyPair: ec.KeyPair) {}
@@ -12,7 +12,23 @@ export class BaseSigner implements L2Signer {
   }
 
   public async signMessage(msg: string): Promise<string> {
-    return this.serialize(this.keyPair.sign(fixMessage(msg)));
+    return this.serialize(this.keyPair.sign(this.fixMessage(msg)));
+  }
+
+  private fixMessage(msg: string): string {
+    msg = encUtils.removeHexPrefix(msg);
+    msg = new BN(msg, 16).toString(16);
+
+    if (msg.length <= 62) {
+      // In this case, msg should not be transformed, as the byteLength() is at most 31,
+      // so delta < 0 (see _truncateToN).
+      return msg;
+    }
+    if (msg.length !== 63) {
+      throw new Error(Errors.StarkCurveInvalidMessageLength);
+    }
+    // In this case delta will be 4 so we perform a shift-left of 4 bits by adding a ZERO_BN.
+    return `${msg}0`;
   }
 
   private serialize(sig: ec.Signature): string {

--- a/src/utils/stark/base-signer.ts
+++ b/src/utils/stark/base-signer.ts
@@ -1,0 +1,24 @@
+import { ec } from 'elliptic';
+import * as encUtils from 'enc-utils';
+import { L2Signer } from '../../types';
+import { fixMessage } from './stark-curve';
+
+
+export class BaseSigner implements L2Signer {
+  constructor(private keyPair: ec.KeyPair) {}
+
+  public getAddress(): string {
+    return this.keyPair.getPublic(true, 'hex');
+  }
+
+  public async signMessage(msg: string): Promise<string> {
+    return this.serialize(this.keyPair.sign(fixMessage(msg)));
+  }
+
+  private serialize(sig: ec.Signature): string {
+    return encUtils.addHexPrefix(
+      encUtils.padLeft(sig.r.toString(16), 64) +
+        encUtils.padLeft(sig.s.toString(16), 64),
+    );
+  }
+}

--- a/src/workflows/trades.ts
+++ b/src/workflows/trades.ts
@@ -1,15 +1,16 @@
-import { L1Signer, L2Signer } from '../types';
+import { L1Signer, L2Signer, StarkWallet } from '../types';
 import { GetSignableTradeRequest, TradesApi } from '../api';
-import { signRaw } from '../utils';
+import { serializeSignature, sign, signRaw } from '../utils';
+import { Signer } from 'ethers';
 
 export async function createTradeWorkflow(
-  l1Signer: L1Signer,
-  l2Signer: L2Signer,
+  signer: Signer,
+  starkWallet: StarkWallet,
   request: GetSignableTradeRequest,
   tradesApi: TradesApi,
 ) {
   // Obtain Ethereum Address from signer
-  const ethAddress = await l1Signer.getAddress();
+  const ethAddress = await signer.getAddress();
 
   const signableResult = await tradesApi.getSignableTrade({
     getSignableTradeRequest: {
@@ -23,9 +24,58 @@ export async function createTradeWorkflow(
     signableResult.data;
 
   // Sign message with L1 credentials
-  const ethSignature = await signRaw(signableMessage, l1Signer);
+  const ethSignature = await signRaw(signableMessage, signer);
 
   // Sign hash with L2 credentials
+  const starkSignature = serializeSignature(
+    sign(starkWallet.starkKeyPair, payloadHash),
+  );
+
+  const createTradeResponse = await tradesApi.createTrade({
+    createTradeRequest: {
+      amount_buy: signableResult.data.amount_buy,
+      amount_sell: signableResult.data.amount_sell,
+      asset_id_buy: signableResult.data.asset_id_buy,
+      asset_id_sell: signableResult.data.asset_id_sell,
+      expiration_timestamp: signableResult.data.expiration_timestamp,
+      fee_info: signableResult.data.fee_info,
+      fees: request.fees,
+      include_fees: true,
+      nonce: signableResult.data.nonce,
+      order_id: request.order_id,
+      stark_key: signableResult.data.stark_key,
+      vault_id_buy: signableResult.data.vault_id_buy,
+      vault_id_sell: signableResult.data.vault_id_sell,
+      stark_signature: starkSignature,
+    },
+    xImxEthAddress: ethAddress,
+    xImxEthSignature: ethSignature,
+  });
+
+  return createTradeResponse.data;
+}
+
+export async function createTradeWorkflowV2(
+  l1Signer: L1Signer,
+  l2Signer: L2Signer,
+  request: GetSignableTradeRequest,
+  tradesApi: TradesApi,
+) {
+  const ethAddress = await l1Signer.getAddress();
+
+  const signableResult = await tradesApi.getSignableTrade({
+    getSignableTradeRequest: {
+      user: ethAddress,
+      order_id: request.order_id,
+      fees: request.fees,
+    },
+  });
+
+  const { signable_message: signableMessage, payload_hash: payloadHash } =
+    signableResult.data;
+
+  const ethSignature = await signRaw(signableMessage, l1Signer);
+
   const starkSignature = await l2Signer.signMessage(payloadHash);
 
   const createTradeResponse = await tradesApi.createTrade({

--- a/src/workflows/trades.ts
+++ b/src/workflows/trades.ts
@@ -55,7 +55,7 @@ export async function createTradeWorkflow(
   return createTradeResponse.data;
 }
 
-export async function createTradeWorkflowV2(
+export async function createTradeWorkflowWithSigner(
   l1Signer: L1Signer,
   l2Signer: L2Signer,
   request: GetSignableTradeRequest,

--- a/src/workflows/trades.ts
+++ b/src/workflows/trades.ts
@@ -5,7 +5,6 @@ import { signRaw } from '../utils';
 export async function createTradeWorkflow(
   l1Signer: L1Signer,
   l2Signer: L2Signer,
-  l2Message: string,
   request: GetSignableTradeRequest,
   tradesApi: TradesApi,
 ) {
@@ -20,13 +19,14 @@ export async function createTradeWorkflow(
     },
   });
 
-  const { signable_message: signableMessage } = signableResult.data;
+  const { signable_message: signableMessage, payload_hash: payloadHash } =
+    signableResult.data;
 
   // Sign message with L1 credentials
   const ethSignature = await signRaw(signableMessage, l1Signer);
 
   // Sign hash with L2 credentials
-  const starkSignature = await l2Signer.signMessage(l2Message);
+  const starkSignature = await l2Signer.signMessage(payloadHash);
 
   const createTradeResponse = await tradesApi.createTrade({
     createTradeRequest: {

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -290,15 +290,8 @@ export class Workflows {
   public createTrade(
     l1Signer: L1Signer,
     l2Signer: L2Signer,
-    l2Message: string,
     request: GetSignableTradeRequest,
   ) {
-    return createTradeWorkflow(
-      l1Signer,
-      l2Signer,
-      l2Message,
-      request,
-      this.tradesApi,
-    );
+    return createTradeWorkflow(l1Signer, l2Signer, request, this.tradesApi);
   }
 }

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -33,7 +33,7 @@ import {
   prepareWithdrawalWorkflow,
 } from './withdrawal';
 import { createOrderWorkflow, cancelOrderWorkflow } from './orders';
-import { createTradeWorkflow } from './trades';
+import { createTradeWorkflow, createTradeWorkflowV2 } from './trades';
 import {
   UnsignedMintRequest,
   UnsignedTransferRequest,
@@ -287,11 +287,20 @@ export class Workflows {
     return cancelOrderWorkflow(signer, starkWallet, request, this.ordersApi);
   }
 
+  /** @deprecated */
   public createTrade(
+    signer: Signer,
+    starkWallet: StarkWallet,
+    request: GetSignableTradeRequest,
+  ) {
+    return createTradeWorkflow(signer, starkWallet, request, this.tradesApi);
+  }
+
+  public createTradeV2(
     l1Signer: L1Signer,
     l2Signer: L2Signer,
     request: GetSignableTradeRequest,
   ) {
-    return createTradeWorkflow(l1Signer, l2Signer, request, this.tradesApi);
+    return createTradeWorkflowV2(l1Signer, l2Signer, request, this.tradesApi);
   }
 }

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -50,6 +50,8 @@ import {
   ERC20Withdrawal,
   TokenWithdrawal,
   StarkWallet,
+  L1Signer,
+  L2Signer,
 } from '../types';
 import { Registration__factory } from '../contracts';
 
@@ -286,10 +288,17 @@ export class Workflows {
   }
 
   public createTrade(
-    signer: Signer,
-    starkWallet: StarkWallet,
+    l1Signer: L1Signer,
+    l2Signer: L2Signer,
+    l2Message: string,
     request: GetSignableTradeRequest,
   ) {
-    return createTradeWorkflow(signer, starkWallet, request, this.tradesApi);
+    return createTradeWorkflow(
+      l1Signer,
+      l2Signer,
+      l2Message,
+      request,
+      this.tradesApi,
+    );
   }
 }

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -33,7 +33,7 @@ import {
   prepareWithdrawalWorkflow,
 } from './withdrawal';
 import { createOrderWorkflow, cancelOrderWorkflow } from './orders';
-import { createTradeWorkflow, createTradeWorkflowV2 } from './trades';
+import { createTradeWorkflow, createTradeWorkflowWithSigner } from './trades';
 import {
   UnsignedMintRequest,
   UnsignedTransferRequest,
@@ -296,11 +296,11 @@ export class Workflows {
     return createTradeWorkflow(signer, starkWallet, request, this.tradesApi);
   }
 
-  public createTradeV2(
+  public createTradeWithSigner(
     l1Signer: L1Signer,
     l2Signer: L2Signer,
     request: GetSignableTradeRequest,
   ) {
-    return createTradeWorkflowV2(l1Signer, l2Signer, request, this.tradesApi);
+    return createTradeWorkflowWithSigner(l1Signer, l2Signer, request, this.tradesApi);
   }
 }


### PR DESCRIPTION
# Summary
* Introduces BaseSigner, a default implementation of the Stark L2Signer interface something like: `@ethers/Signer`.
* Add `createTradeWorkflowWithSigner` function to enable creating trade workflow with l2signer

# Why the changes
* Not tight the workflow to the ways of how L2Wallet to sign the message.
* Allows having different l2Signer implementation which knows and defines the **signMessage** themselves.
* In that way, **core-sdk** would have it BaseSigner knows how to sign the message, also **wallet-sdk** would implement their own l2Wallet Signer to define how to **signMessage** 

# Things worth calling out
* To avoid breaking change, we follow the release plan: https://imtbl.slack.com/archives/C035V01VBKL/p1656553279539269?thread_ts=1656486878.526449&cid=C035V01VBKL
* Tested the function from this imx-testing repo: [PR](https://github.com/immutable/imx-testing/pull/72)