### PR TITLE
Add registerOffchainWithSigner function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added `registerOffchainWithSigner` function to enable register offchain user with L2Signer
+
+### Changed
+- mark `registerOffchain` as deprecated
+
+### Fixed
+- `getAddress` method from BaseSigner
+
 ## [0.4.0] - 2022-07-05
 ### Added
 - Added `BaseSigner`, a default implementation of the Stark L2Signer interface

--- a/src/utils/stark/base-signer.ts
+++ b/src/utils/stark/base-signer.ts
@@ -3,12 +3,13 @@ import { ec } from 'elliptic';
 import * as encUtils from 'enc-utils';
 import { L2Signer } from '../../types';
 import { Errors } from '../../workflows/errors';
+import { getXCoordinate } from './stark-key';
 
 export class BaseSigner implements L2Signer {
   constructor(private keyPair: ec.KeyPair) {}
 
   public getAddress(): string {
-    return this.keyPair.getPublic(true, 'hex');
+    return encUtils.sanitizeHex(getXCoordinate(this.keyPair.getPublic(true, 'hex')));
   }
 
   public async signMessage(msg: string): Promise<string> {

--- a/src/workflows/registration.ts
+++ b/src/workflows/registration.ts
@@ -1,24 +1,20 @@
 import { Signer } from '@ethersproject/abstract-signer';
-import {
-  serializeSignature,
-  sign,
-  signRaw,
-} from '../utils';
+import { serializeSignature, sign, signRaw } from '../utils';
 import {
   GetSignableRegistrationResponse,
   RegisterUserResponse,
   UsersApi,
 } from '../api';
 import { Registration } from '../contracts';
-import { StarkWallet } from '../types';
+import { L2Signer, StarkWallet } from '../types';
 
+/** @deprecated */
 export async function registerOffchainWorkflow(
   signer: Signer,
   starkWallet: StarkWallet,
   usersApi: UsersApi,
 ): Promise<RegisterUserResponse> {
-
-  const userAddress = (await signer.getAddress());
+  const userAddress = await signer.getAddress();
 
   // Get signable details for offchain registration
   const signableResult = await usersApi.getSignableRegistrationOffchain({
@@ -39,13 +35,53 @@ export async function registerOffchainWorkflow(
     sign(starkWallet.starkKeyPair, payloadHash),
   );
 
-  // Send request for user registratin offchain
+  // Send request for user registration offchain
   const response = await usersApi.registerUser({
     registerUserRequest: {
       eth_signature: ethSignature,
       ether_key: userAddress,
       stark_signature: starkSignature,
       stark_key: starkWallet.starkPublicKey,
+    },
+  });
+
+  return {
+    tx_hash: response.data.tx_hash,
+  };
+}
+
+export async function registerOffchainWorkflowWithSigner(
+  l1Signer: Signer,
+  l2Signer: L2Signer,
+  usersApi: UsersApi,
+): Promise<RegisterUserResponse> {
+  const userAddress = await l1Signer.getAddress();
+  const starkPublicKey = await l2Signer.getAddress();
+
+  // Get signable details for offchain registration
+  const signableResult = await usersApi.getSignableRegistrationOffchain({
+    getSignableRegistrationRequest: {
+      ether_key: userAddress,
+      stark_key: starkPublicKey,
+    },
+  });
+
+  const { signable_message: signableMessage, payload_hash: payloadHash } =
+    signableResult.data;
+
+  // Sign message with L1 credentials
+  const ethSignature = await signRaw(signableMessage, l1Signer);
+
+  // Sign hash with L2 credentials
+  const starkSignature = await l2Signer.signMessage(payloadHash);
+
+  // Send request for user registration offchain
+  const response = await usersApi.registerUser({
+    registerUserRequest: {
+      eth_signature: ethSignature,
+      ether_key: userAddress,
+      stark_signature: starkSignature,
+      stark_key: starkPublicKey,
     },
   });
 

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -17,6 +17,7 @@ import {
 import {
   isRegisteredOnChainWorkflow,
   registerOffchainWorkflow,
+  registerOffchainWorkflowWithSigner,
 } from './registration';
 import { mintingWorkflow } from './minting';
 import { transfersWorkflow, batchTransfersWorkflow } from './transfers';
@@ -79,8 +80,14 @@ export class Workflows {
     this.withdrawalsApi = new WithdrawalsApi(config.api);
   }
 
+  /** @deprecated */
   public registerOffchain(signer: Signer, starkWallet: StarkWallet) {
     return registerOffchainWorkflow(signer, starkWallet, this.usersApi);
+  }
+
+
+  public registerOffchainWithSigner(l1Signer: L1Signer, l2Signer: L2Signer) {
+    return registerOffchainWorkflowWithSigner(l1Signer, l2Signer, this.usersApi);
   }
 
   public isRegisteredOnchain(signer: Signer, starkWallet: StarkWallet) {


### PR DESCRIPTION
# Summary
### Added
- Added `registerOffchainWithSigner` function to enable register offchain user with l2signer
### Changed
- mark `registerOffchain` as deprecated
### Fixed
- `getAddress` method from BaseSigner

# Why the changes
This is one of the series changes that we do to replace the **starkwallet** to **l2signer** to sign the message. 
the previous reference PR is: https://github.com/immutable/imx-core-sdk/pull/78

# Things worth calling out
Tested the function from this **imx-testing** repo: https://github.com/immutable/imx-testing/pull/73

