### PR TITLE
Add burnWithSigner function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `createOrderWithSigner` function to enable create order with l2signer
 - Added `cancelOrderWithSigner` function to enable cancel order with l2signer
 - Added `WalletConnection` type
+- Added `burnWithSigner` function to enable burn with l2signer
 
 ### Deprecated
 
 - `createOrder`, use `createOrderWithSigner` instead
 - `cancelOrder`, use `cancelOrderWithSigner` instead
+- `burn`, use `burnWithSigner` instead
 
 ## [0.5.0] - 2022-07-12
 

--- a/src/workflows/burn.ts
+++ b/src/workflows/burn.ts
@@ -1,4 +1,4 @@
-import { Signer as L1Signer } from '@ethersproject/abstract-signer';
+import { Signer } from '@ethersproject/abstract-signer';
 import {
   TransfersApi,
   CreateTransferResponseV1,
@@ -16,7 +16,7 @@ type burnWorkflowWithSignerRequest = WalletConnection & {
 
 /** @deprecated */
 export async function burnWorkflow(
-  signer: L1Signer,
+  signer: Signer,
   starkWallet: StarkWallet,
   request: GetSignableBurnRequest,
   transfersApi: TransfersApi,

--- a/src/workflows/burn.ts
+++ b/src/workflows/burn.ts
@@ -1,4 +1,4 @@
-import { Signer } from '@ethersproject/abstract-signer';
+import { Signer as L1Signer } from '@ethersproject/abstract-signer';
 import {
   TransfersApi,
   CreateTransferResponseV1,
@@ -7,10 +7,16 @@ import {
 import { serializeSignature, sign, signRaw } from '../utils';
 import { BurnAddress } from './constants';
 import { GetSignableBurnRequest } from './types';
-import { StarkWallet } from '../types';
+import { StarkWallet, WalletConnection } from '../types';
 
+type burnWorkflowWithSignerRequest = WalletConnection & {
+  request: GetSignableBurnRequest;
+  transfersApi: TransfersApi;
+};
+
+/** @deprecated */
 export async function burnWorkflow(
-  signer: Signer,
+  signer: L1Signer,
   starkWallet: StarkWallet,
   request: GetSignableBurnRequest,
   transfersApi: TransfersApi,
@@ -38,6 +44,62 @@ export async function burnWorkflow(
 
   // Obtain Ethereum Address from signer
   const ethAddress = (await signer.getAddress());
+
+  // Assemble transfer params
+  const transferSigningParams = {
+    sender_stark_key: signableResult.data.sender_stark_key!,
+    sender_vault_id: signableResult.data.sender_vault_id,
+    receiver_stark_key: signableResult.data.receiver_stark_key,
+    receiver_vault_id: signableResult.data.receiver_vault_id,
+    asset_id: signableResult.data.asset_id,
+    amount: signableResult.data.amount,
+    nonce: signableResult.data.nonce,
+    expiration_timestamp: signableResult.data.expiration_timestamp,
+    stark_signature: starkSignature,
+  };
+
+  // create transfer
+  const response = await transfersApi.createTransferV1({
+    createTransferRequest: transferSigningParams,
+    xImxEthAddress: ethAddress,
+    xImxEthSignature: ethSignature,
+  });
+
+  return {
+    sent_signature: response?.data.sent_signature,
+    status: response?.data.status?.toString(),
+    time: response?.data.time,
+    transfer_id: response?.data.transfer_id,
+  };
+}
+
+export async function burnWorkflowWithSigner({
+  l1Signer,
+  l2Signer,
+  request,
+  transfersApi,
+}: burnWorkflowWithSignerRequest): Promise<CreateTransferResponseV1> {
+  // Get signable response for transfer
+  const signableResult = await transfersApi.getSignableTransferV1({
+    getSignableTransferRequest: {
+      sender: request.sender,
+      token: request.token,
+      amount: request.amount,
+      receiver: BurnAddress.BurnEthAddress,
+    },
+  });
+
+  const { signable_message: signableMessage, payload_hash: payloadHash } =
+    signableResult.data;
+
+  // Sign message with L1 credentials
+  const ethSignature = await signRaw(signableMessage, l1Signer);
+
+  // Sign hash with L2 credentials
+  const starkSignature = await l2Signer.signMessage(payloadHash);
+
+  // Obtain Ethereum Address from signer
+  const ethAddress = (await l1Signer.getAddress());
 
   // Assemble transfer params
   const transferSigningParams = {

--- a/src/workflows/burn.ts
+++ b/src/workflows/burn.ts
@@ -8,7 +8,11 @@ import { transfersWorkflowWithSigner } from './transfers';
 import { serializeSignature, sign, signRaw } from '../utils';
 import { BurnAddress } from './constants';
 import { GetSignableBurnRequest } from './types';
-import { StarkWallet, WalletConnection } from '../types';
+import {
+  StarkWallet,
+  WalletConnection,
+  UnsignedTransferRequest,
+} from '../types';
 
 type burnWorkflowWithSignerParams = WalletConnection & {
   request: GetSignableBurnRequest;
@@ -80,20 +84,17 @@ export async function burnWorkflowWithSigner({
   request,
   transfersApi,
 }: burnWorkflowWithSignerParams): Promise<CreateTransferResponseV1> {
-  // Get signable response for transfer
-  const signableResult = await transfersApi.getSignableTransferV1({
-    getSignableTransferRequest: {
-      sender: request.sender,
-      receiver: BurnAddress.BurnEthAddress,
-      token: request.token,
-      amount: request.amount,
-    },
-  });
+  const transferRequest: UnsignedTransferRequest = {
+    sender: request.sender,
+    receiver: BurnAddress.BurnEthAddress,
+    token: request.token,
+    amount: request.amount,
+  }
 
   return transfersWorkflowWithSigner({
     l1Signer,
     l2Signer,
-    request: signableResult.request,
+    request: transferRequest,
     transfersApi,
   });
 }

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -26,7 +26,11 @@ import {
   depositERC721Workflow,
   depositEthWorkflow,
 } from './deposit';
-import { burnWorkflow, getBurnWorkflow } from './burn';
+import {
+  burnWorkflow,
+  getBurnWorkflow,
+  burnWorkflowWithSigner,
+} from './burn';
 import {
   completeERC20WithdrawalWorfklow,
   completeERC721WithdrawalWorkflow,
@@ -91,7 +95,6 @@ export class Workflows {
     return registerOffchainWorkflow(signer, starkWallet, this.usersApi);
   }
 
-
   public registerOffchainWithSigner(l1Signer: L1Signer, l2Signer: L2Signer) {
     return registerOffchainWorkflowWithSigner(l1Signer, l2Signer, this.usersApi);
   }
@@ -134,12 +137,17 @@ export class Workflows {
     );
   }
 
+  /** @deprecated */
   public burn(
     signer: Signer,
     starkWallet: StarkWallet,
     request: UnsignedBurnRequest,
   ) {
     return burnWorkflow(signer, starkWallet, request, this.transfersApi);
+  }
+
+  public burnWithSigner(walletConnection: WalletConnection, request: UnsignedBurnRequest) {
+    return burnWorkflowWithSigner({ ...walletConnection, request, transfersApi: this.transfersApi });
   }
 
   public getBurn(request: TransfersApiGetTransferRequest) {


### PR DESCRIPTION
# Summary
### Added
- Added `burnWithSigner` function to enable burn NFTs with l2signer

### Changed
- mark `burn` as deprecated

# Why the changes
This is one of the series changes that we do to replace the **starkwallet** to **l2signer** to sign the message. 
the previous reference PR is: https://github.com/immutable/imx-core-sdk/pull/78

# Things worth calling out
Tested the function from this **imx-testing** repo: https://github.com/immutable/imx-testing/pull/78