### PR TITLE
getStarkPublicKeyWithXCoordinate method returns the same as generateStarkWallet returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `batchNftTransferWithSigner` function to enable batch transfer with l2signer
 - Added `prepareWithdrawalWorkflowWithSigner` function to enable prepare withdrawal with l2signer
 - Added `burnWithSigner` function to enable burn with l2signer
-
-### Fixed
-
-- `getStarkPublicKey` method to get the same public key as the `generateStarkWallet` returns
+- Added `getStarkPublicKeyWithXCoordinate` method to get the same public key as the `generateStarkWallet` returns
 
 ### Deprecated
 
@@ -28,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `batchNftTransfer`, use `batchNftTransferWithSigner` instead
 - `prepareWithdrawalWorkflow`, use `prepareWithdrawalWorkflowWithSigner` instead
 - `burn`, use `burnWithSigner` instead
+- `getStarkPublicKey`, use BaseSigner's `getAddress` instead
 
 ## [0.5.0] - 2022-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `prepareWithdrawalWorkflowWithSigner` function to enable prepare withdrawal with l2signer
 - Added `burnWithSigner` function to enable burn with l2signer
 
+### Fixed
+
+- `getStarkPublicKey` method to get the same public key as the `generateStarkWallet` returns
+
 ### Deprecated
 
 - `createOrder`, use `createOrderWithSigner` instead

--- a/src/utils/stark/stark-key.ts
+++ b/src/utils/stark/stark-key.ts
@@ -73,7 +73,7 @@ export function getPublic(keyPair: ec.KeyPair, compressed = false): string {
 }
 
 export function getStarkPublicKey(keyPair: ec.KeyPair): string {
-  return getPublic(keyPair, true);
+  return encUtils.sanitizeHex(getXCoordinate(getPublic(keyPair, true)));
 }
 
 export function getKeyPairFromPublicKey(publicKey: string): ec.KeyPair {
@@ -105,10 +105,10 @@ export async function generateStarkWalletFromSignedMessage(ethAddress: string, s
     DEFAULT_ACCOUNT_INDEX,
   );
   const keyPair = getKeyPairFromPath(splitSignature(signature).s, path);
-  const starkPublic = getStarkPublicKey(keyPair);
+  const starkPublicKey = getStarkPublicKey(keyPair);
   return {
     path,
-    starkPublicKey: encUtils.sanitizeHex(getXCoordinate(starkPublic)),
+    starkPublicKey,
     starkKeyPair: keyPair,
   };
 }

--- a/src/utils/stark/stark-key.ts
+++ b/src/utils/stark/stark-key.ts
@@ -72,7 +72,12 @@ export function getPublic(keyPair: ec.KeyPair, compressed = false): string {
   return keyPair.getPublic(compressed, 'hex');
 }
 
+/** @deprecated */
 export function getStarkPublicKey(keyPair: ec.KeyPair): string {
+  return getPublic(keyPair, true);
+}
+
+function getStarkPublicKeyWithXCoordinate(keyPair: ec.KeyPair): string {
   return encUtils.sanitizeHex(getXCoordinate(getPublic(keyPair, true)));
 }
 
@@ -94,10 +99,13 @@ export async function generateStarkWallet(
 ): Promise<StarkWallet> {
   const ethAddress = (await signer.getAddress()).toLowerCase();
   const signature = await signer.signMessage(DEFAULT_SIGNATURE_MESSAGE);
-  return generateStarkWalletFromSignedMessage(ethAddress, signature)
+  return generateStarkWalletFromSignedMessage(ethAddress, signature);
 }
 
-export async function generateStarkWalletFromSignedMessage(ethAddress: string, signature: string) : Promise<StarkWallet> {
+export async function generateStarkWalletFromSignedMessage(
+  ethAddress: string,
+  signature: string,
+): Promise<StarkWallet> {
   const path = getAccountPath(
     DEFAULT_ACCOUNT_LAYER,
     DEFAULT_ACCOUNT_APPLICATION,
@@ -105,7 +113,7 @@ export async function generateStarkWalletFromSignedMessage(ethAddress: string, s
     DEFAULT_ACCOUNT_INDEX,
   );
   const keyPair = getKeyPairFromPath(splitSignature(signature).s, path);
-  const starkPublicKey = getStarkPublicKey(keyPair);
+  const starkPublicKey = getStarkPublicKeyWithXCoordinate(keyPair);
   return {
     path,
     starkPublicKey,


### PR DESCRIPTION
# Summary
When I was using the `getStarkPublicKey` method to get my public key, I found the key I get is not the same as the first time generated. 

ex: the first time generated starts from '**0x**123456', but this starts from '**07**123456'


# Why the changes
So I proposed this change to ensure every other time, when getting the stark public key, it always gets the same one as the first time generating stark key returns.
To avoid breaking changes also to better scope the function. added
the private `getStarkPublicKeyWithXCoordinate`

# Things worth calling out

