### PR TITLE
Updating functions to suit Wallets SDK WalletConnection object

### DIFF
--- a/src/workflows/registration.ts
+++ b/src/workflows/registration.ts
@@ -6,7 +6,7 @@ import {
   UsersApi,
 } from '../api';
 import { Registration } from '../contracts';
-import { L2Signer, StarkWallet } from '../types';
+import { WalletConnection, StarkWallet } from '../types';
 
 /** @deprecated */
 export async function registerOffchainWorkflow(
@@ -51,12 +51,11 @@ export async function registerOffchainWorkflow(
 }
 
 export async function registerOffchainWorkflowWithSigner(
-  l1Signer: Signer,
-  l2Signer: L2Signer,
+  walletConnection: WalletConnection,
   usersApi: UsersApi,
 ): Promise<void> {
-  const userAddress = await l1Signer.getAddress();
-  const starkPublicKey = l2Signer.getAddress();
+  const userAddress = await walletConnection.l1Signer.getAddress();
+  const starkPublicKey = walletConnection.l2Signer.getAddress();
 
   if (await isUserRegistered(userAddress, usersApi)) {
     return;
@@ -74,10 +73,10 @@ export async function registerOffchainWorkflowWithSigner(
     signableResult.data;
 
   // Sign message with L1 credentials
-  const ethSignature = await signRaw(signableMessage, l1Signer);
+  const ethSignature = await signRaw(signableMessage, walletConnection.l1Signer);
 
   // Sign hash with L2 credentials
-  const starkSignature = await l2Signer.signMessage(payloadHash);
+  const starkSignature = await walletConnection.l2Signer.signMessage(payloadHash);
 
   // Send request for user registration offchain
   await usersApi.registerUser({

--- a/src/workflows/registration.ts
+++ b/src/workflows/registration.ts
@@ -8,6 +8,10 @@ import {
 import { Registration } from '../contracts';
 import { WalletConnection, StarkWallet } from '../types';
 
+type registerOffchainWorkflowWithSignerParams = WalletConnection & {
+  usersApi: UsersApi,
+};
+
 /** @deprecated */
 export async function registerOffchainWorkflow(
   signer: Signer,
@@ -50,12 +54,13 @@ export async function registerOffchainWorkflow(
   };
 }
 
-export async function registerOffchainWorkflowWithSigner(
-  walletConnection: WalletConnection,
-  usersApi: UsersApi,
-): Promise<void> {
-  const userAddress = await walletConnection.l1Signer.getAddress();
-  const starkPublicKey = walletConnection.l2Signer.getAddress();
+export async function registerOffchainWorkflowWithSigner({
+  l1Signer,
+  l2Signer,
+  usersApi,
+}: registerOffchainWorkflowWithSignerParams): Promise<void> {
+  const userAddress = await l1Signer.getAddress();
+  const starkPublicKey = l2Signer.getAddress();
 
   if (await isUserRegistered(userAddress, usersApi)) {
     return;
@@ -73,10 +78,10 @@ export async function registerOffchainWorkflowWithSigner(
     signableResult.data;
 
   // Sign message with L1 credentials
-  const ethSignature = await signRaw(signableMessage, walletConnection.l1Signer);
+  const ethSignature = await signRaw(signableMessage, l1Signer);
 
   // Sign hash with L2 credentials
-  const starkSignature = await walletConnection.l2Signer.signMessage(payloadHash);
+  const starkSignature = await l2Signer.signMessage(payloadHash);
 
   // Send request for user registration offchain
   await usersApi.registerUser({

--- a/src/workflows/trades.ts
+++ b/src/workflows/trades.ts
@@ -1,4 +1,4 @@
-import { L1Signer, L2Signer, StarkWallet } from '../types';
+import { WalletConnection, StarkWallet } from '../types';
 import { GetSignableTradeRequest, TradesApi } from '../api';
 import { serializeSignature, sign, signRaw } from '../utils';
 import { Signer } from 'ethers';
@@ -56,12 +56,11 @@ export async function createTradeWorkflow(
 }
 
 export async function createTradeWorkflowWithSigner(
-  l1Signer: L1Signer,
-  l2Signer: L2Signer,
+  walletConnection: WalletConnection,
   request: GetSignableTradeRequest,
   tradesApi: TradesApi,
 ) {
-  const ethAddress = await l1Signer.getAddress();
+  const ethAddress = await walletConnection.l1Signer.getAddress();
 
   const signableResult = await tradesApi.getSignableTrade({
     getSignableTradeRequest: {
@@ -74,9 +73,9 @@ export async function createTradeWorkflowWithSigner(
   const { signable_message: signableMessage, payload_hash: payloadHash } =
     signableResult.data;
 
-  const ethSignature = await signRaw(signableMessage, l1Signer);
+  const ethSignature = await signRaw(signableMessage, walletConnection.l1Signer);
 
-  const starkSignature = await l2Signer.signMessage(payloadHash);
+  const starkSignature = await walletConnection.l2Signer.signMessage(payloadHash);
 
   const createTradeResponse = await tradesApi.createTrade({
     createTradeRequest: {

--- a/src/workflows/trades.ts
+++ b/src/workflows/trades.ts
@@ -1,8 +1,14 @@
 import { WalletConnection, StarkWallet } from '../types';
-import { GetSignableTradeRequest, TradesApi } from '../api';
+import { CreateTradeResponse, GetSignableTradeRequest, TradesApi } from '../api';
 import { serializeSignature, sign, signRaw } from '../utils';
 import { Signer } from 'ethers';
 
+type createTradeWorkflowWithSignerParams = WalletConnection & {
+  request: GetSignableTradeRequest,
+  tradesApi: TradesApi,
+};
+
+/** @deprecated */
 export async function createTradeWorkflow(
   signer: Signer,
   starkWallet: StarkWallet,
@@ -55,12 +61,13 @@ export async function createTradeWorkflow(
   return createTradeResponse.data;
 }
 
-export async function createTradeWorkflowWithSigner(
-  walletConnection: WalletConnection,
-  request: GetSignableTradeRequest,
-  tradesApi: TradesApi,
-) {
-  const ethAddress = await walletConnection.l1Signer.getAddress();
+export async function createTradeWorkflowWithSigner({
+  l1Signer,
+  l2Signer,
+  request,
+  tradesApi,
+}: createTradeWorkflowWithSignerParams) : Promise<CreateTradeResponse> {
+  const ethAddress = await l1Signer.getAddress();
 
   const signableResult = await tradesApi.getSignableTrade({
     getSignableTradeRequest: {
@@ -73,9 +80,9 @@ export async function createTradeWorkflowWithSigner(
   const { signable_message: signableMessage, payload_hash: payloadHash } =
     signableResult.data;
 
-  const ethSignature = await signRaw(signableMessage, walletConnection.l1Signer);
+  const ethSignature = await signRaw(signableMessage, l1Signer);
 
-  const starkSignature = await walletConnection.l2Signer.signMessage(payloadHash);
+  const starkSignature = await l2Signer.signMessage(payloadHash);
 
   const createTradeResponse = await tradesApi.createTrade({
     createTradeRequest: {

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -101,7 +101,7 @@ export class Workflows {
   }
 
   public registerOffchainWithSigner(walletConnection: WalletConnection) {
-    return registerOffchainWorkflowWithSigner(walletConnection, this.usersApi);
+    return registerOffchainWorkflowWithSigner({ ...walletConnection, usersApi: this.usersApi });
   }
 
   public isRegisteredOnchain(signer: Signer, starkWallet: StarkWallet) {
@@ -365,6 +365,6 @@ export class Workflows {
     walletConnection: WalletConnection,
     request: GetSignableTradeRequest,
   ) {
-    return createTradeWorkflowWithSigner(walletConnection, request, this.tradesApi);
+    return createTradeWorkflowWithSigner({ ...walletConnection, request, tradesApi: this.tradesApi });
   }
 }

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -66,8 +66,6 @@ import {
   ERC20Withdrawal,
   TokenWithdrawal,
   StarkWallet,
-  L1Signer,
-  L2Signer,
   PrepareWithdrawalRequest,
 } from '../types';
 import { Registration__factory } from '../contracts';
@@ -102,8 +100,8 @@ export class Workflows {
     return registerOffchainWorkflow(signer, starkWallet, this.usersApi);
   }
 
-  public registerOffchainWithSigner(l1Signer: L1Signer, l2Signer: L2Signer) {
-    return registerOffchainWorkflowWithSigner(l1Signer, l2Signer, this.usersApi);
+  public registerOffchainWithSigner(walletConnection: WalletConnection) {
+    return registerOffchainWorkflowWithSigner(walletConnection, this.usersApi);
   }
 
   public isRegisteredOnchain(signer: Signer, starkWallet: StarkWallet) {
@@ -364,10 +362,9 @@ export class Workflows {
   }
 
   public createTradeWithSigner(
-    l1Signer: L1Signer,
-    l2Signer: L2Signer,
+    walletConnection: WalletConnection,
     request: GetSignableTradeRequest,
   ) {
-    return createTradeWorkflowWithSigner(l1Signer, l2Signer, request, this.tradesApi);
+    return createTradeWorkflowWithSigner(walletConnection, request, this.tradesApi);
   }
 }


### PR DESCRIPTION
# Summary
### Changed
- registerOffchainWithSigner to use WalletConnection instead of isolated signers
- createTradeWithSigner to use WalletConnection instead of isolated signers

# Why the changes
Following the last definitions on how the Wallets SDK outcome will look like, it was needed to update on Core SDK the function parameters to suit the Wallets SDK output.

# Things worth calling out
Tests were also updated on **imx-testing** through this [PR](https://github.com/immutable/imx-testing/pull/80)