### PR TITLE
Add isRegisteredOnchainWithSigner workflow function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+
+- Added `isRegisteredOnchainWithSigner` function to enable verify user registration onchain with WalletConnection
+
+### Deprecated
+
+- `isRegisteredOnchain`, use `isRegisteredOnchainWithSigner` instead
+
 ## [0.6.0] - 2022-07-18
 ### Added
 

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -104,6 +104,7 @@ export class Workflows {
     return registerOffchainWorkflowWithSigner({ ...walletConnection, usersApi: this.usersApi });
   }
 
+  /** @deprecated */
   public isRegisteredOnchain(signer: Signer, starkWallet: StarkWallet) {
     // Get instance of registration contract
     const registrationContract = Registration__factory.connect(
@@ -113,6 +114,19 @@ export class Workflows {
 
     return isRegisteredOnChainWorkflow(
       starkWallet.starkPublicKey,
+      registrationContract,
+    );
+  }
+
+  public isRegisteredOnchainWithSigner(walletConnection: WalletConnection) {
+    // Get instance of registration contract
+    const registrationContract = Registration__factory.connect(
+      this.config.registrationContractAddress,
+      walletConnection.l1Signer,
+    );
+
+    return isRegisteredOnChainWorkflow(
+      walletConnection.l2Signer.getAddress(),
       registrationContract,
     );
   }


### PR DESCRIPTION
# Summary
### Added
- Added `isRegisteredOnchainWithSigner` function to enable checking registration onchain with the Wallets SDK WalletConnection object

### Changed
- mark `isRegisteredOnchain` as deprecated

# Why the changes
This is one of the series changes that we do to replace the **starkwallet** to **l2signer** to sign the message.

# Things worth calling out
Tests were also updated on **imx-testing** through this [PR](https://github.com/immutable/imx-testing/pull/81)