### PR TITLE
Removing the deprecated methods and renaming the ones those have the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,29 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Removed
-
-- Removed the deprecated `registerOffchain` method
-- Removed the deprecated `isRegisteredOnchain` method
-- Removed the deprecated `transfer` method
-- Removed the deprecated `batchNftTransfer` method
-- Removed the deprecated `burn` method
-- Removed the deprecated `prepareWithdrawal` method
-- Removed the deprecated `createOrder` method
-- Removed the deprecated `cancelOrder` method
-- Removed the deprecated `createTrade` method
 
 ### Changed
 
-- Renamed the `registerOffchainWithSigner` method to `registerOffchain`
-- Renamed the `isRegisteredOnchainWithSigner` method to `isRegisteredOnchain`
-- Renamed the `transferWithSigner` method to `transfer`
-- Renamed the `batchNftTransferWithSigner` method to `batchNftTransfer`
-- Renamed the `burnWithSigner` method to `burn`
-- Renamed the `prepareWithdrawalWithSigner` method to `prepareWithdrawal`
-- Renamed the `createOrderWithSigner` method to `createOrder`
-- Renamed the `cancelOrderWithSigner` method to `cancelOrder`
-- Renamed the `createTradeWithSigner` method to `createTrade`
+- [BREAKING CHANGE] Renamed the `registerOffchainWithSigner` method to `registerOffchain`
+- [BREAKING CHANGE] Renamed the `isRegisteredOnchainWithSigner` method to `isRegisteredOnchain`
+- [BREAKING CHANGE] Renamed the `transferWithSigner` method to `transfer`
+- [BREAKING CHANGE] Renamed the `batchNftTransferWithSigner` method to `batchNftTransfer`
+- [BREAKING CHANGE] Renamed the `burnWithSigner` method to `burn`
+- [BREAKING CHANGE] Renamed the `prepareWithdrawalWithSigner` method to `prepareWithdrawal`
+- [BREAKING CHANGE] Renamed the `createOrderWithSigner` method to `createOrder`
+- [BREAKING CHANGE] Renamed the `cancelOrderWithSigner` method to `cancelOrder`
+- [BREAKING CHANGE] Renamed the `createTradeWithSigner` method to `createTrade`
+
+### Removed
+
+- [BREAKING CHANGE] Removed the deprecated `registerOffchain` method
+- [BREAKING CHANGE] Removed the deprecated `isRegisteredOnchain` method
+- [BREAKING CHANGE] Removed the deprecated `transfer` method
+- [BREAKING CHANGE] Removed the deprecated `batchNftTransfer` method
+- [BREAKING CHANGE] Removed the deprecated `burn` method
+- [BREAKING CHANGE] Removed the deprecated `prepareWithdrawal` method
+- [BREAKING CHANGE] Removed the deprecated `createOrder` method
+- [BREAKING CHANGE] Removed the deprecated `cancelOrder` method
+- [BREAKING CHANGE] Removed the deprecated `createTrade` method
 
 ## [0.6.0] - 2022-07-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Removed
 
-- Added `isRegisteredOnchainWithSigner` function to enable verify user registration onchain with WalletConnection
+- Removed the deprecated `registerOffchain` method
+- Removed the deprecated `isRegisteredOnchain` method
+- Removed the deprecated `transfer` method
+- Removed the deprecated `batchNftTransfer` method
+- Removed the deprecated `burn` method
+- Removed the deprecated `prepareWithdrawal` method
+- Removed the deprecated `createOrder` method
+- Removed the deprecated `cancelOrder` method
+- Removed the deprecated `createTrade` method
 
-### Deprecated
+### Changed
 
-- `isRegisteredOnchain`, use `isRegisteredOnchainWithSigner` instead
+- Renamed the `registerOffchainWithSigner` method to `registerOffchain`
+- Renamed the `isRegisteredOnchainWithSigner` method to `isRegisteredOnchain`
+- Renamed the `transferWithSigner` method to `transfer`
+- Renamed the `batchNftTransferWithSigner` method to `batchNftTransfer`
+- Renamed the `burnWithSigner` method to `burn`
+- Renamed the `prepareWithdrawalWithSigner` method to `prepareWithdrawal`
+- Renamed the `createOrderWithSigner` method to `createOrder`
+- Renamed the `cancelOrderWithSigner` method to `cancelOrder`
+- Renamed the `createTradeWithSigner` method to `createTrade`
 
 ## [0.6.0] - 2022-07-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Changed
 
 - [BREAKING CHANGE] Renamed the `registerOffchainWithSigner` method to `registerOffchain`

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ const signer = new Wallet(privateKey).connect(provider);
 
 #### WalletConnection
 
-WalletConnection is a top level connector which contains all the needed resources (eg.: signers for L1 and L2) to possibilitate Core SDK workflows usage.
+WalletConnection is a top level connector which contains all the required resources (eg. L1 and L2 signers) to enable usage of the Core SDK workflows.
 
 ```ts
 import { AlchemyProvider } from '@ethersproject/providers';

--- a/README.md
+++ b/README.md
@@ -58,32 +58,33 @@ const ethNetwork = 'ropsten'; // or mainnet;
 // Use the helper function to get the config
 const config = getConfig(ethNetwork);
 
-// Setup a provider and signer
+// Setup a provider and a signer
 const privateKey = YOUR_PRIVATE_KEY;
 const provider = new AlchemyProvider(ethNetwork, YOUR_ALCHEMY_API_KEY);
 const signer = new Wallet(privateKey).connect(provider);
 ```
 
-#### Stark Wallet
+#### WalletConnection
 
-Some methods require a stark wallet as a parameter. The Core SDK expects you will generate your own stark wallet.
+WalletConnection is a top level connector which contains all the needed resources (eg.: signers for L1 and L2) to possibilitate Core SDK workflows usage.
 
 ```ts
+import { AlchemyProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
-import { generateStarkWallet } from '@imtbl/core-sdk';
+import { WalletConnection, generateStarkWallet, BaseSigner } from '@imtbl/core-sdk';
 
-// generate your own stark wallet
-const generateWallets = async (provider: AlchemyProvider) => {
+// Generate your own WalletConnection
+const generateWalletConnection = async (provider: AlchemyProvider) : Promise<WalletConnection> => {
   // L1 credentials
-  const wallet = Wallet.createRandom().connect(provider);
+  const l1Signer = Wallet.createRandom().connect(provider);
 
   // L2 credentials
-  // Obtain stark key pair associated with this user
-  const starkWallet = await generateStarkWallet(wallet); // this is sdk helper function
+  const starkWallet = await generateStarkWallet(l1Signer);
+  const l2Signer = new BaseSigner(starkWallet);
 
   return {
-    wallet,
-    starkWallet,
+    l1Signer,
+    l2Signer,
   };
 };
 ```
@@ -243,8 +244,8 @@ The current workflow methods exposed from the `Workflow` class.
 | `depositERC721`            | Deposit ERC721 NFT to L2 wallet.                                             |
 | `prepareWithdrawal`        | Prepare token for withdrawal.                                                |
 | `completeEthWithdrawal`    | withdraw ETH to L1.                                                          |
-| `completeERC20Withdrawal`  | withdraw ERC20 to L1.                                                      |
-| `completeERC721Withdrawal` | withdraw ERC721 to L1.                                                     |
+| `completeERC20Withdrawal`  | withdraw ERC20 to L1.                                                        |
+| `completeERC721Withdrawal` | withdraw ERC721 to L1.                                                       |
 | `completeWithdrawal`       | Helper method around withdrawal methods. Withdraw based on token type.       |
 | `createOrder`              | Create an order to sell an asset.                                            |
 | `cancelOrder`              | Cancel an order.                                                             |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ const generateWalletConnection = async (provider: AlchemyProvider) : Promise<Wal
 
   // L2 credentials
   const starkWallet = await generateStarkWallet(l1Signer);
-  const l2Signer = new BaseSigner(starkWallet);
+  const l2Signer = new BaseSigner(starkWallet.starkKeyPair);
 
   return {
     l1Signer,
@@ -204,23 +204,35 @@ A workflow is a combination of API and contract calls required for more complica
 // User registration workflow example
 import { AlchemyProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
-import { getConfig, Workflows } from '@imtbl/core-sdk';
+import { 
+  Workflows, 
+  BaseSigner, 
+  getConfig, 
+  generateStarkWallet,
+} from '@imtbl/core-sdk';
 
-const alchemyApiKey = YOUR_ALCHEMY_API_KEY;
 const ethNetwork = 'ropsten';
 
-// Setup provider and signer
-const provider = new AlchemyProvider(ethNetwork, alchemyApiKey);
-const signer = new Wallet(privateKey).connect(provider);
+// Sets up the provider
+const alchemyApiKey = 'UPDATE WITH THE ALCHEMY API KEY HERE';
+const alchemyProvider = new AlchemyProvider(ethNetwork, alchemyApiKey);
 
-// Configure Core SDK Workflow class
-const config = getConfig(ethNetwork);
-const workflows = new Workflows(config);
+// Sets up the L1Signer
+const privateKey = 'UPDATE WITH THE PRIVATE KEY HERE';
+const l1Wallet = new Wallet(privateKey);
+const l1Signer = l1Wallet.connect(alchemyProvider);
 
-const registerUser = async () => {
-  const response = await workflows.registerOffchain(signer);
-  console.log(response);
-};
+// Sets up the L2Signer
+const l2Wallet = await generateStarkWallet(l1Signer);
+const l2Signer = new BaseSigner(l2Wallet.starkKeyPair);
+
+// Sets up the Core SDK workflows
+const coreSdkConfig = getConfig(ethNetwork);
+const coreSdkWorkflows = new Workflows(coreSdkConfig);
+
+// Registers the user
+const walletConnection = { l1Signer, l2Signer };
+await coreSdkWorkflows.registerOffchain(walletConnection);
 ```
 
 The workflow can be found in the [workflows directory](src/workflows/).

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,18 +8,18 @@ import {
 import { GetSignableBurnRequest } from '../workflows/types';
 import { Signer as L1Signer } from '@ethersproject/abstract-signer';
 
-export interface StarkWallet {
-  path: string;
-  starkPublicKey: string;
-  starkKeyPair: ec.KeyPair;
-}
+export { L1Signer };
 
 export interface L2Signer {
   signMessage(message: string): Promise<string>;
   getAddress(): string;
 }
 
-export { Signer as L1Signer } from '@ethersproject/abstract-signer';
+export interface StarkWallet {
+  path: string;
+  starkPublicKey: string;
+  starkKeyPair: ec.KeyPair;
+}
 
 export interface WalletConnection {
   l1Signer: L1Signer;

--- a/src/utils/crypto/crypto.ts
+++ b/src/utils/crypto/crypto.ts
@@ -36,14 +36,6 @@ export function grindKey(privateKey: string): string {
   return key.mod(ORDER).toString('hex');
 }
 
-//called after "sign" when using signable endpoints
-export function serializeSignature(sig: SignatureOptions): string {
-  return encUtils.addHexPrefix(
-    encUtils.padLeft(sig.r.toString(16), 64) +
-      encUtils.padLeft(sig.s.toString(16), 64),
-  );
-}
-
 // used to sign message with L1 keys. Used for registration
 export function serializeEthSignature(sig: SignatureOptions): string {
   // This is because golang appends a recovery param

--- a/src/utils/stark/stark-curve.ts
+++ b/src/utils/stark/stark-curve.ts
@@ -1,6 +1,5 @@
 import * as encUtils from 'enc-utils';
 import BN from 'bn.js';
-import { ec } from 'elliptic';
 import { Errors } from '../../workflows/errors';
 
 export function getIntFromBits(
@@ -28,8 +27,4 @@ export function fixMessage(msg: string) {
   }
   // In this case delta will be 4 so we perform a shift-left of 4 bits by adding a ZERO_BN.
   return `${msg}0`;
-}
-
-export function sign(keyPair: ec.KeyPair, msg: string): ec.Signature {
-  return keyPair.sign(fixMessage(msg));
 }

--- a/src/workflows/deposit/depositERC20.ts
+++ b/src/workflows/deposit/depositERC20.ts
@@ -77,7 +77,6 @@ export async function depositERC20Workflow(
   encodingApi: EncodingApi,
   config: Config,
 ): Promise<TransactionResponse> {
-  // Configure request parameters
   const user = await signer.getAddress();
 
   // Get decimals for this specific ERC20
@@ -99,7 +98,6 @@ export async function depositERC20Workflow(
   );
   await signer.sendTransaction(approveTransaction);
 
-  // Get signable deposit details
   const getSignableDepositRequest = {
     user,
     token: {
@@ -131,19 +129,16 @@ export async function depositERC20Workflow(
   const vaultId = signableDepositResult.data.vault_id;
   const quantizedAmount = BigNumber.from(signableDepositResult.data.amount);
 
-  // Get instance of core contract
   const coreContract = Core__factory.connect(
     config.starkContractAddress,
     signer,
   );
 
-  // Get instance of registration contract
   const registrationContract = Registration__factory.connect(
     config.registrationContractAddress,
     signer,
   );
 
-  // Check if user is registered onchain
   const isRegistered = await isRegisteredOnChainWorkflow(
     starkPublicKey,
     registrationContract,

--- a/src/workflows/deposit/depositERC721.ts
+++ b/src/workflows/deposit/depositERC721.ts
@@ -76,7 +76,6 @@ export async function depositERC721Workflow(
   encodingApi: EncodingApi,
   config: Config,
 ): Promise<TransactionResponse> {
-  // Configure request parameters
   const user = await signer.getAddress();
 
   const data: ERC721TokenData = {
@@ -94,7 +93,6 @@ export async function depositERC721Workflow(
   );
   await signer.sendTransaction(approveTransaction);
 
-  // Get signable deposit details
   const getSignableDepositRequest = {
     user,
     token: {
@@ -126,19 +124,16 @@ export async function depositERC721Workflow(
   const starkPublicKey = signableDepositResult.data.stark_key;
   const vaultId = signableDepositResult.data.vault_id;
 
-  // Get instance of core contract
   const coreContract = Core__factory.connect(
     config.starkContractAddress,
     signer,
   );
 
-  // Get instance of registration contract
   const registrationContract = Registration__factory.connect(
     config.registrationContractAddress,
     signer,
   );
 
-  // Check if user is registered onchain
   const isRegistered = await isRegisteredOnChainWorkflow(
     starkPublicKey,
     registrationContract,

--- a/src/workflows/deposit/depositEth.ts
+++ b/src/workflows/deposit/depositEth.ts
@@ -66,14 +66,12 @@ export async function depositEthWorkflow(
   encodingApi: EncodingApi,
   config: Config,
 ): Promise<TransactionResponse> {
-  // Configure request parameters
   const user = await signer.getAddress();
   const data: ETHTokenData = {
     decimals: 18,
   };
   const amount = parseEther(deposit.amount);
 
-  // Get signable deposit details
   const getSignableDepositRequest = {
     user,
     token: {
@@ -100,19 +98,16 @@ export async function depositEthWorkflow(
   const starkPublicKey = signableDepositResult.data.stark_key;
   const vaultId = signableDepositResult.data.vault_id;
 
-  // Get instance of core contract
   const coreContract = Core__factory.connect(
     config.starkContractAddress,
     signer,
   );
 
-  // Get instance of registration contract
   const registrationContract = Registration__factory.connect(
     config.registrationContractAddress,
     signer,
   );
 
-  // Check if user is registered onchain
   const isRegistered = await isRegisteredOnChainWorkflow(
     starkPublicKey,
     registrationContract,

--- a/src/workflows/minting.ts
+++ b/src/workflows/minting.ts
@@ -46,7 +46,6 @@ export async function mintingWorkflow(
     auth_signature: '',
   };
 
-  // Sign payload using L1 credentials
   const hash = keccak256(toUtf8Bytes(JSON.stringify(signablePayload)));
   const authSignature = await signRaw(hash, signer);
 

--- a/src/workflows/orders.ts
+++ b/src/workflows/orders.ts
@@ -30,13 +30,10 @@ export async function createOrderWorkflow({
   const { signable_message: signableMessage, payload_hash: payloadHash } =
     getSignableOrderResponse.data;
 
-  // Sign message with L1 credentials
   const ethSignature = await signRaw(signableMessage, l1Signer);
 
-  // Sign hash with L2 credentials
   const starkSignature = await l2Signer.signMessage(payloadHash);
 
-  // Obtain Eth address from signer
   const ethAddress = await l1Signer.getAddress();
 
   const resp = getSignableOrderResponse.data;
@@ -84,13 +81,10 @@ export async function cancelOrderWorkflow({
   const { signable_message: signableMessage, payload_hash: payloadHash } =
     getSignableCancelOrderResponse.data;
 
-  // Sign message with L1 credentials
   const ethSignature = await signRaw(signableMessage, l1Signer);
 
-  // Sign hash with L2 credentials
   const starkSignature = await l2Signer.signMessage(payloadHash);
 
-  // Obtain Ethereum Address from signer
   const ethAddress = await l1Signer.getAddress();
 
   const cancelOrderResponse = await ordersApi.cancelOrder({

--- a/src/workflows/orders.ts
+++ b/src/workflows/orders.ts
@@ -1,84 +1,28 @@
-import { Signer } from '@ethersproject/abstract-signer';
-import { StarkWallet } from '../types';
 import {
-  GetSignableCancelOrderRequest,
-  GetSignableOrderRequest,
   OrdersApi,
   OrdersApiCreateOrderRequest,
+  GetSignableOrderRequest,
+  GetSignableCancelOrderRequest,
 } from '../api';
-import { serializeSignature, sign, signRaw } from '../utils';
-import { WalletConnection } from '../types/index';
+import { WalletConnection } from '../types';
+import { signRaw } from '../utils';
 
-type CreateOrderWorkflowWithSignerRequest = WalletConnection & {
+type CreateOrderWorkflowParams = WalletConnection & {
   request: GetSignableOrderRequest;
   ordersApi: OrdersApi;
 };
 
-type CancelOrderWorkflowWithSignerRequest = WalletConnection & {
+type CancelOrderWorkflowParams = WalletConnection & {
   request: GetSignableCancelOrderRequest;
   ordersApi: OrdersApi;
 };
 
-/** @deprecated */
-export async function createOrderWorkflow(
-  signer: Signer,
-  starkWallet: StarkWallet,
-  request: GetSignableOrderRequest,
-  ordersApi: OrdersApi,
-) {
-  const getSignableOrderResponse = await ordersApi.getSignableOrder({
-    getSignableOrderRequestV3: request,
-  });
-
-  const { signable_message: signableMessage, payload_hash: payloadHash } =
-    getSignableOrderResponse.data;
-
-  // Sign message with L1 credentials
-  const ethSignature = await signRaw(signableMessage, signer);
-
-  // Sign has with L2 credentials
-  const starkSignature = serializeSignature(
-    sign(starkWallet.starkKeyPair, payloadHash),
-  );
-
-  // Obtain Eth address from signer
-  const ethAddress = await signer.getAddress();
-
-  const resp = getSignableOrderResponse.data;
-
-  const orderParams: OrdersApiCreateOrderRequest = {
-    createOrderRequest: {
-      amount_buy: resp.amount_buy,
-      amount_sell: resp.amount_sell,
-      asset_id_buy: resp.asset_id_buy,
-      asset_id_sell: resp.asset_id_sell,
-      expiration_timestamp: resp.expiration_timestamp,
-      include_fees: true,
-      fees: request.fees,
-      nonce: resp.nonce,
-      stark_key: resp.stark_key,
-      stark_signature: starkSignature,
-      vault_id_buy: resp.vault_id_buy,
-      vault_id_sell: resp.vault_id_sell,
-    },
-    xImxEthAddress: ethAddress,
-    xImxEthSignature: ethSignature,
-  };
-
-  const createOrderResponse = await ordersApi.createOrder(orderParams);
-
-  return {
-    // order_id, status, time
-    ...createOrderResponse.data,
-  };
-}
-
-export async function createOrderWorkflowWithSigner({
+export async function createOrderWorkflow({
   l1Signer,
   l2Signer,
   request,
   ordersApi,
-}: CreateOrderWorkflowWithSignerRequest) {
+}: CreateOrderWorkflowParams) {
   const getSignableOrderResponse = await ordersApi.getSignableOrder({
     getSignableOrderRequestV3: request,
   });
@@ -123,57 +67,12 @@ export async function createOrderWorkflowWithSigner({
   };
 }
 
-/** @deprecated */
-export async function cancelOrderWorkflow(
-  signer: Signer,
-  starkWallet: StarkWallet,
-  request: GetSignableCancelOrderRequest,
-  ordersApi: OrdersApi,
-) {
-  const getSignableCancelOrderResponse = await ordersApi.getSignableCancelOrder(
-    {
-      getSignableCancelOrderRequest: {
-        order_id: request.order_id,
-      },
-    },
-  );
-
-  const { signable_message: signableMessage, payload_hash: payloadHash } =
-    getSignableCancelOrderResponse.data;
-
-  // Sign message with L1 credentials
-  const ethSignature = await signRaw(signableMessage, signer);
-
-  // Sign hash with L2 credentials
-  const starkSignature = serializeSignature(
-    sign(starkWallet.starkKeyPair, payloadHash),
-  );
-
-  // Obtain Ethereum Address from signer
-  const ethAddress = await signer.getAddress();
-
-  const cancelOrderResponse = await ordersApi.cancelOrder({
-    id: request.order_id.toString(),
-    cancelOrderRequest: {
-      order_id: request.order_id,
-      stark_signature: starkSignature,
-    },
-    xImxEthAddress: ethAddress,
-    xImxEthSignature: ethSignature,
-  });
-
-  return {
-    order_id: cancelOrderResponse.data.order_id,
-    status: cancelOrderResponse.data.status,
-  };
-}
-
-export async function cancelOrderWorkflowWithSigner({
+export async function cancelOrderWorkflow({
   l1Signer,
   l2Signer,
   request,
   ordersApi,
-}: CancelOrderWorkflowWithSignerRequest) {
+}: CancelOrderWorkflowParams) {
   const getSignableCancelOrderResponse = await ordersApi.getSignableCancelOrder(
     {
       getSignableCancelOrderRequest: {

--- a/src/workflows/registration.ts
+++ b/src/workflows/registration.ts
@@ -31,7 +31,6 @@ export async function registerOffchainWorkflow({
     return;
   }
 
-  // Get signable details for offchain registration
   const signableResult = await usersApi.getSignableRegistrationOffchain({
     getSignableRegistrationRequest: {
       ether_key: userAddress,
@@ -42,13 +41,10 @@ export async function registerOffchainWorkflow({
   const { signable_message: signableMessage, payload_hash: payloadHash } =
     signableResult.data;
 
-  // Sign message with L1 credentials
   const ethSignature = await signRaw(signableMessage, l1Signer);
 
-  // Sign hash with L2 credentials
   const starkSignature = await l2Signer.signMessage(payloadHash);
 
-  // Send request for user registration offchain
   await usersApi.registerUser({
     registerUserRequest: {
       eth_signature: ethSignature,

--- a/src/workflows/trades.ts
+++ b/src/workflows/trades.ts
@@ -1,76 +1,22 @@
-import { WalletConnection, StarkWallet } from '../types';
 import {
-  CreateTradeResponse,
-  GetSignableTradeRequest,
   TradesApi,
+  GetSignableTradeRequest,
+  CreateTradeResponse,
 } from '../api';
-import { serializeSignature, sign, signRaw } from '../utils';
-import { Signer } from 'ethers';
+import { WalletConnection } from '../types';
+import { signRaw } from '../utils';
 
-type createTradeWorkflowWithSignerParams = WalletConnection & {
+type createTradeWorkflowParams = WalletConnection & {
   request: GetSignableTradeRequest;
   tradesApi: TradesApi;
 };
 
-/** @deprecated */
-export async function createTradeWorkflow(
-  signer: Signer,
-  starkWallet: StarkWallet,
-  request: GetSignableTradeRequest,
-  tradesApi: TradesApi,
-) {
-  // Obtain Ethereum Address from signer
-  const ethAddress = await signer.getAddress();
-
-  const signableResult = await tradesApi.getSignableTrade({
-    getSignableTradeRequest: {
-      user: ethAddress,
-      order_id: request.order_id,
-      fees: request.fees,
-    },
-  });
-
-  const { signable_message: signableMessage, payload_hash: payloadHash } =
-    signableResult.data;
-
-  // Sign message with L1 credentials
-  const ethSignature = await signRaw(signableMessage, signer);
-
-  // Sign hash with L2 credentials
-  const starkSignature = serializeSignature(
-    sign(starkWallet.starkKeyPair, payloadHash),
-  );
-
-  const createTradeResponse = await tradesApi.createTrade({
-    createTradeRequest: {
-      amount_buy: signableResult.data.amount_buy,
-      amount_sell: signableResult.data.amount_sell,
-      asset_id_buy: signableResult.data.asset_id_buy,
-      asset_id_sell: signableResult.data.asset_id_sell,
-      expiration_timestamp: signableResult.data.expiration_timestamp,
-      fee_info: signableResult.data.fee_info,
-      fees: request.fees,
-      include_fees: true,
-      nonce: signableResult.data.nonce,
-      order_id: request.order_id,
-      stark_key: signableResult.data.stark_key,
-      vault_id_buy: signableResult.data.vault_id_buy,
-      vault_id_sell: signableResult.data.vault_id_sell,
-      stark_signature: starkSignature,
-    },
-    xImxEthAddress: ethAddress,
-    xImxEthSignature: ethSignature,
-  });
-
-  return createTradeResponse.data;
-}
-
-export async function createTradeWorkflowWithSigner({
+export async function createTradeWorkflow({
   l1Signer,
   l2Signer,
   request,
   tradesApi,
-}: createTradeWorkflowWithSignerParams): Promise<CreateTradeResponse> {
+}: createTradeWorkflowParams): Promise<CreateTradeResponse> {
   const ethAddress = await l1Signer.getAddress();
 
   const signableResult = await tradesApi.getSignableTrade({

--- a/src/workflows/transfers.ts
+++ b/src/workflows/transfers.ts
@@ -1,30 +1,28 @@
-import { Signer } from '@ethersproject/abstract-signer';
-import { signRaw } from '../utils';
 import {
   TransfersApi,
-  GetSignableTransferRequestV1,
-  CreateTransferResponseV1,
   GetSignableTransferRequest,
+  GetSignableTransferRequestV1,
   CreateTransferResponse,
+  CreateTransferResponseV1,
 } from '../api';
-import { serializeSignature, sign } from '../utils';
-import { StarkWallet, WalletConnection } from '../types';
+import { WalletConnection } from '../types';
+import { signRaw } from '../utils';
 
-type TransferRequestParams = WalletConnection & {
+type TransfersWorkflowParams = WalletConnection & {
   request: GetSignableTransferRequestV1;
   transfersApi: TransfersApi;
 };
-type BatchTransferRequestParams = WalletConnection & {
+type BatchTransfersWorkflowParams = WalletConnection & {
   request: GetSignableTransferRequest;
   transfersApi: TransfersApi;
 };
 
-export async function transfersWorkflowWithSigner({
+export async function transfersWorkflow({
   l1Signer,
   l2Signer,
   request,
   transfersApi,
-}: TransferRequestParams): Promise<CreateTransferResponseV1> {
+}: TransfersWorkflowParams): Promise<CreateTransferResponseV1> {
   // Get signable response for transfer
   const signableResult = await transfersApi.getSignableTransferV1({
     getSignableTransferRequest: {
@@ -76,127 +74,12 @@ export async function transfersWorkflowWithSigner({
   };
 }
 
-export async function transfersWorkflow(
-  signer: Signer,
-  starkWallet: StarkWallet,
-  request: GetSignableTransferRequestV1,
-  transfersApi: TransfersApi,
-): Promise<CreateTransferResponseV1> {
-  // Get signable response for transfer
-  const signableResult = await transfersApi.getSignableTransferV1({
-    getSignableTransferRequest: {
-      sender: request.sender,
-      token: request.token,
-      amount: request.amount,
-      receiver: request.receiver,
-    },
-  });
-
-  const { signable_message: signableMessage, payload_hash: payloadHash } =
-    signableResult.data;
-
-  // Sign message with L1 credentials
-  const ethSignature = await signRaw(signableMessage, signer);
-
-  // Sign hash with L2 credentials
-  const starkSignature = serializeSignature(
-    sign(starkWallet.starkKeyPair, payloadHash),
-  );
-
-  // Obtain Ethereum Address from signer
-  const ethAddress = await signer.getAddress();
-
-  // Assemble transfer params
-  const transferSigningParams = {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    sender_stark_key: signableResult.data.sender_stark_key!,
-    sender_vault_id: signableResult.data.sender_vault_id,
-    receiver_stark_key: signableResult.data.receiver_stark_key,
-    receiver_vault_id: signableResult.data.receiver_vault_id,
-    asset_id: signableResult.data.asset_id,
-    amount: signableResult.data.amount,
-    nonce: signableResult.data.nonce,
-    expiration_timestamp: signableResult.data.expiration_timestamp,
-    stark_signature: starkSignature,
-  };
-
-  // create transfer
-  const response = await transfersApi.createTransferV1({
-    createTransferRequest: transferSigningParams,
-    xImxEthAddress: ethAddress,
-    xImxEthSignature: ethSignature,
-  });
-
-  return {
-    sent_signature: response?.data.sent_signature,
-    status: response?.data.status?.toString(),
-    time: response?.data.time,
-    transfer_id: response?.data.transfer_id,
-  };
-}
-
-export async function batchTransfersWorkflow(
-  signer: Signer,
-  starkWallet: StarkWallet,
-  request: GetSignableTransferRequest,
-  transfersApi: TransfersApi,
-): Promise<CreateTransferResponse> {
-  // Get signable response for transfer
-  const signableResult = await transfersApi.getSignableTransfer({
-    getSignableTransferRequestV2: {
-      sender_ether_key: request.sender_ether_key,
-      signable_requests: request.signable_requests,
-    },
-  });
-
-  const signableMessage = signableResult.data.signable_message;
-
-  if (signableMessage === undefined) {
-    throw new Error('Invalid response from Signable registration offchain');
-  }
-
-  // Obtain Ethereum Address from signer
-  const ethAddress = await signer.getAddress();
-
-  // Sign message with L1 credentials
-  const ethSignature = await signRaw(signableMessage, signer);
-
-  // TODO: throw error on missing payload hash?
-  // Assemble transfer params and sign payload hash
-  const transferSigningParams = {
-    sender_stark_key: signableResult.data.sender_stark_key,
-    requests: signableResult.data.signable_responses.map(resp => ({
-      sender_vault_id: resp.sender_vault_id,
-      receiver_stark_key: resp.receiver_stark_key,
-      receiver_vault_id: resp.receiver_vault_id,
-      asset_id: resp.asset_id,
-      amount: resp.amount,
-      nonce: resp.nonce,
-      expiration_timestamp: resp.expiration_timestamp,
-      stark_signature: serializeSignature(
-        sign(starkWallet.starkKeyPair, resp.payload_hash),
-      ),
-    })),
-  };
-
-  // create transfer
-  const response = await transfersApi.createTransfer({
-    createTransferRequestV2: transferSigningParams,
-    xImxEthAddress: ethAddress,
-    xImxEthSignature: ethSignature,
-  });
-
-  return {
-    transfer_ids: response?.data.transfer_ids,
-  };
-}
-
-export async function batchTransfersWorkflowWithSigner({
+export async function batchTransfersWorkflow({
   l1Signer,
   l2Signer,
   request,
   transfersApi,
-}: BatchTransferRequestParams): Promise<CreateTransferResponse> {
+}: BatchTransfersWorkflowParams): Promise<CreateTransferResponse> {
   // Get signable response for transfer
   const signableResult = await transfersApi.getSignableTransfer({
     getSignableTransferRequestV2: {

--- a/src/workflows/withdrawal/completeERC20Withdrawal.ts
+++ b/src/workflows/withdrawal/completeERC20Withdrawal.ts
@@ -72,19 +72,16 @@ export async function completeERC20WithdrawalWorfklow(
     },
   );
 
-  // Get instance of core contract
   const coreContract = Core__factory.connect(
     config.starkContractAddress,
     signer,
   );
 
-  // Get instance of registration contract
   const registrationContract = Registration__factory.connect(
     config.registrationContractAddress,
     signer,
   );
 
-  // Check if user is registered onchain
   const isRegistered = await isRegisteredOnChainWorkflow(
     starkPublicKey,
     registrationContract,

--- a/src/workflows/withdrawal/completeERC721Withdrawal.ts
+++ b/src/workflows/withdrawal/completeERC721Withdrawal.ts
@@ -94,19 +94,16 @@ async function completeMintableERC721Withdrawal(
   );
   const mintingBlob = getMintingBlob(token);
 
-  // Get instance of core contract
   const coreContract = Core__factory.connect(
     config.starkContractAddress,
     signer,
   );
 
-  // Get instance of registration contract
   const registrationContract = Registration__factory.connect(
     config.registrationContractAddress,
     signer,
   );
 
-  // Check if user is registered onchain
   const isRegistered = await isRegisteredOnChainWorkflow(
     starkPublicKey,
     registrationContract,
@@ -193,19 +190,16 @@ async function completeERC721Withdrawal(
     },
   );
 
-  // Get instance of core contract
   const coreContract = Core__factory.connect(
     config.starkContractAddress,
     signer,
   );
 
-  // Get instance of registration contract
   const registrationContract = Registration__factory.connect(
     config.registrationContractAddress,
     signer,
   );
 
-  // Check if user is registered onchain
   const isRegistered = await isRegisteredOnChainWorkflow(
     starkPublicKey,
     registrationContract,
@@ -266,8 +260,7 @@ export async function completeERC721WithdrawalWorkflow(
     )
     .catch(error => {
       if (error.response.status === 404) {
-        // token is already minted on L1
-        console.log(error.response);
+        console.log(error.response); // token is already minted on L1
         return completeERC721Withdrawal(
           signer,
           starkPublicKey,

--- a/src/workflows/withdrawal/completeEthWithdrawal.ts
+++ b/src/workflows/withdrawal/completeEthWithdrawal.ts
@@ -63,19 +63,16 @@ export async function completeEthWithdrawalWorkflow(
 ) {
   const assetType = await getEncodeAssetInfo('asset', 'ETH', encodingApi);
 
-  // Get instance of core contract
   const coreContract = Core__factory.connect(
     config.starkContractAddress,
     signer,
   );
 
-  // Get instance of registration contract
   const registrationContract = Registration__factory.connect(
     config.registrationContractAddress,
     signer,
   );
 
-  // Check if user is registered onchain
   const isRegistered = await isRegisteredOnChainWorkflow(
     starkPublicKey,
     registrationContract,

--- a/src/workflows/withdrawal/prepareWithdrawal.ts
+++ b/src/workflows/withdrawal/prepareWithdrawal.ts
@@ -34,7 +34,6 @@ export async function prepareWithdrawalWorkflow({
   const { signable_message: signableMessage, payload_hash: payloadHash } =
     signableWithdrawalResult.data;
 
-  // Sign hash with L2 credentials
   const starkSignature = await l2Signer.signMessage(payloadHash);
 
   const { ethAddress, ethSignature } = await signMessage(

--- a/src/workflows/withdrawal/prepareWithdrawal.ts
+++ b/src/workflows/withdrawal/prepareWithdrawal.ts
@@ -1,31 +1,28 @@
-import { Signer } from '@ethersproject/abstract-signer';
-import { serializeSignature, sign, signMessage } from '../../utils';
-import { CreateWithdrawalResponse, WithdrawalsApi } from '../../api';
+import { WithdrawalsApi, CreateWithdrawalResponse } from '../../api';
 import {
   convertToSignableRequestFormat,
   PrepareWithdrawalRequest,
-  StarkWallet,
-  TokenPrepareWithdrawal,
   WalletConnection,
 } from '../../types';
+import { signMessage } from '../../utils';
 
 const assertIsDefined = <T>(value?: T): T => {
   if (value !== undefined) return value;
   throw new Error('undefined field exception');
 };
 
-type PrepareWithdrawalRequestParams = PrepareWithdrawalRequest &
+type PrepareWithdrawalWorkflowParams = PrepareWithdrawalRequest &
   WalletConnection & {
     withdrawalsApi: WithdrawalsApi;
   };
 
-export async function prepareWithdrawalWorkflowWithSigner({
+export async function prepareWithdrawalWorkflow({
   l1Signer,
   l2Signer,
   token,
   quantity,
   withdrawalsApi,
-}: PrepareWithdrawalRequestParams): Promise<CreateWithdrawalResponse> {
+}: PrepareWithdrawalWorkflowParams): Promise<CreateWithdrawalResponse> {
   const signableWithdrawalResult = await withdrawalsApi.getSignableWithdrawal({
     getSignableWithdrawalRequest: {
       user: await l1Signer.getAddress(),
@@ -43,50 +40,6 @@ export async function prepareWithdrawalWorkflowWithSigner({
   const { ethAddress, ethSignature } = await signMessage(
     signableMessage,
     l1Signer,
-  );
-
-  const prepareWithdrawalResponse = await withdrawalsApi.createWithdrawal({
-    createWithdrawalRequest: {
-      stark_key: assertIsDefined(signableWithdrawalResult.data.stark_key),
-      amount: quantity.toString(),
-      asset_id: assertIsDefined(signableWithdrawalResult.data.asset_id),
-      vault_id: assertIsDefined(signableWithdrawalResult.data.vault_id),
-      nonce: assertIsDefined(signableWithdrawalResult.data.nonce),
-      stark_signature: starkSignature,
-    },
-    xImxEthAddress: ethAddress,
-    xImxEthSignature: ethSignature,
-  });
-
-  return prepareWithdrawalResponse.data;
-}
-
-export async function prepareWithdrawalWorkflow(
-  signer: Signer,
-  starkWallet: StarkWallet,
-  token: TokenPrepareWithdrawal,
-  quantity: string,
-  withdrawalsApi: WithdrawalsApi,
-): Promise<CreateWithdrawalResponse> {
-  const signableWithdrawalResult = await withdrawalsApi.getSignableWithdrawal({
-    getSignableWithdrawalRequest: {
-      user: await signer.getAddress(),
-      token: convertToSignableRequestFormat(token),
-      amount: quantity.toString(),
-    },
-  });
-
-  const { signable_message: signableMessage, payload_hash: payloadHash } =
-    signableWithdrawalResult.data;
-
-  // Sign hash with L2 credentials
-  const starkSignature = serializeSignature(
-    sign(starkWallet.starkKeyPair, payloadHash),
-  );
-
-  const { ethAddress, ethSignature } = await signMessage(
-    signableMessage,
-    signer,
   );
 
   const prepareWithdrawalResponse = await withdrawalsApi.createWithdrawal({

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -86,7 +86,6 @@ export class Workflows {
   }
 
   public isRegisteredOnchain(walletConnection: WalletConnection) {
-    // Get instance of registration contract
     const registrationContract = Registration__factory.connect(
       this.config.registrationContractAddress,
       walletConnection.l1Signer,

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -1,4 +1,5 @@
 import { Signer } from '@ethersproject/abstract-signer';
+
 import {
   DepositsApi,
   EncodingApi,
@@ -15,38 +16,6 @@ import {
   TradesApi,
 } from '../api';
 import {
-  isRegisteredOnChainWorkflow,
-  registerOffchainWorkflow,
-  registerOffchainWorkflowWithSigner,
-} from './registration';
-import { mintingWorkflow } from './minting';
-import {
-  transfersWorkflow,
-  batchTransfersWorkflow,
-  transfersWorkflowWithSigner,
-  batchTransfersWorkflowWithSigner,
-} from './transfers';
-import {
-  depositERC20Workflow,
-  depositERC721Workflow,
-  depositEthWorkflow,
-} from './deposit';
-import { burnWorkflow, getBurnWorkflow, burnWorkflowWithSigner } from './burn';
-import {
-  completeERC20WithdrawalWorfklow,
-  completeERC721WithdrawalWorkflow,
-  completeEthWithdrawalWorkflow,
-  prepareWithdrawalWorkflow,
-  prepareWithdrawalWorkflowWithSigner,
-} from './withdrawal';
-import {
-  createOrderWorkflow,
-  cancelOrderWorkflow,
-  cancelOrderWorkflowWithSigner,
-  createOrderWorkflowWithSigner,
-} from './orders';
-import { createTradeWorkflow, createTradeWorkflowWithSigner } from './trades';
-import {
   UnsignedMintRequest,
   UnsignedTransferRequest,
   UnsignedBatchNftTransferRequest,
@@ -56,16 +25,34 @@ import {
   TokenDeposit,
   TokenType,
   UnsignedBurnRequest,
-  TokenPrepareWithdrawal,
   Config,
   ERC721Withdrawal,
   ERC20Withdrawal,
   TokenWithdrawal,
-  StarkWallet,
   PrepareWithdrawalRequest,
+  WalletConnection,
 } from '../types';
 import { Registration__factory } from '../contracts';
-import { WalletConnection } from '../types/index';
+import {
+  isRegisteredOnChainWorkflow,
+  registerOffchainWorkflow,
+} from './registration';
+import { mintingWorkflow } from './minting';
+import { transfersWorkflow, batchTransfersWorkflow } from './transfers';
+import {
+  depositERC20Workflow,
+  depositERC721Workflow,
+  depositEthWorkflow,
+} from './deposit';
+import { getBurnWorkflow, burnWorkflow } from './burn';
+import {
+  completeERC20WithdrawalWorfklow,
+  completeERC721WithdrawalWorkflow,
+  completeEthWithdrawalWorkflow,
+  prepareWithdrawalWorkflow,
+} from './withdrawal';
+import { cancelOrderWorkflow, createOrderWorkflow } from './orders';
+import { createTradeWorkflow } from './trades';
 
 export class Workflows {
   private readonly depositsApi: DepositsApi;
@@ -91,33 +78,14 @@ export class Workflows {
     this.withdrawalsApi = new WithdrawalsApi(config.api);
   }
 
-  /** @deprecated */
-  public registerOffchain(signer: Signer, starkWallet: StarkWallet) {
-    return registerOffchainWorkflow(signer, starkWallet, this.usersApi);
-  }
-
-  public registerOffchainWithSigner(walletConnection: WalletConnection) {
-    return registerOffchainWorkflowWithSigner({
+  public registerOffchain(walletConnection: WalletConnection) {
+    return registerOffchainWorkflow({
       ...walletConnection,
       usersApi: this.usersApi,
     });
   }
 
-  /** @deprecated */
-  public isRegisteredOnchain(signer: Signer, starkWallet: StarkWallet) {
-    // Get instance of registration contract
-    const registrationContract = Registration__factory.connect(
-      this.config.registrationContractAddress,
-      signer,
-    );
-
-    return isRegisteredOnChainWorkflow(
-      starkWallet.starkPublicKey,
-      registrationContract,
-    );
-  }
-
-  public isRegisteredOnchainWithSigner(walletConnection: WalletConnection) {
+  public isRegisteredOnchain(walletConnection: WalletConnection) {
     // Get instance of registration contract
     const registrationContract = Registration__factory.connect(
       this.config.registrationContractAddress,
@@ -134,65 +102,33 @@ export class Workflows {
     return mintingWorkflow(signer, request, this.mintsApi);
   }
 
-  /** @deprecated */
   public transfer(
-    signer: Signer,
-    starkWallet: StarkWallet,
-    request: UnsignedTransferRequest,
-  ) {
-    return transfersWorkflow(signer, starkWallet, request, this.transfersApi);
-  }
-
-  public transferWithSigner(
     walletConnection: WalletConnection,
     request: UnsignedTransferRequest,
   ) {
-    return transfersWorkflowWithSigner({
+    return transfersWorkflow({
       ...walletConnection,
       request,
       transfersApi: this.transfersApi,
     });
   }
 
-  /** @deprecated */
   public batchNftTransfer(
-    signer: Signer,
-    starkWallet: StarkWallet,
-    request: UnsignedBatchNftTransferRequest,
-  ) {
-    return batchTransfersWorkflow(
-      signer,
-      starkWallet,
-      request,
-      this.transfersApi,
-    );
-  }
-
-  public batchNftTransferWithSigner(
     walletConnection: WalletConnection,
     request: UnsignedBatchNftTransferRequest,
   ) {
-    return batchTransfersWorkflowWithSigner({
+    return batchTransfersWorkflow({
       ...walletConnection,
       request,
       transfersApi: this.transfersApi,
     });
   }
 
-  /** @deprecated */
   public burn(
-    signer: Signer,
-    starkWallet: StarkWallet,
-    request: UnsignedBurnRequest,
-  ) {
-    return burnWorkflow(signer, starkWallet, request, this.transfersApi);
-  }
-
-  public burnWithSigner(
     walletConnection: WalletConnection,
     request: UnsignedBurnRequest,
   ) {
-    return burnWorkflowWithSigner({
+    return burnWorkflow({
       ...walletConnection,
       request,
       transfersApi: this.transfersApi,
@@ -270,27 +206,11 @@ export class Workflows {
     );
   }
 
-  /** @deprecated */
   public prepareWithdrawal(
-    signer: Signer,
-    starkWallet: StarkWallet,
-    token: TokenPrepareWithdrawal,
-    quantity: string,
-  ) {
-    return prepareWithdrawalWorkflow(
-      signer,
-      starkWallet,
-      token,
-      quantity,
-      this.withdrawalsApi,
-    );
-  }
-
-  public prepareWithdrawalWithSigner(
     walletConnection: WalletConnection,
     request: PrepareWithdrawalRequest,
   ) {
-    return prepareWithdrawalWorkflowWithSigner({
+    return prepareWithdrawalWorkflow({
       ...walletConnection,
       ...request,
       withdrawalsApi: this.withdrawalsApi,
@@ -353,60 +273,33 @@ export class Workflows {
     }
   }
 
-  /** @deprecated */
   public createOrder(
-    signer: Signer,
-    starkWallet: StarkWallet,
-    request: GetSignableOrderRequest,
-  ) {
-    return createOrderWorkflow(signer, starkWallet, request, this.ordersApi);
-  }
-
-  public createOrderWithSigner(
     walletConnection: WalletConnection,
     request: GetSignableOrderRequest,
   ) {
-    return createOrderWorkflowWithSigner({
+    return createOrderWorkflow({
       ...walletConnection,
       request,
       ordersApi: this.ordersApi,
     });
   }
 
-  /** @deprecated */
   public cancelOrder(
-    signer: Signer,
-    starkWallet: StarkWallet,
-    request: GetSignableCancelOrderRequest,
-  ) {
-    return cancelOrderWorkflow(signer, starkWallet, request, this.ordersApi);
-  }
-
-  public cancelOrderWithSigner(
     walletConnection: WalletConnection,
     request: GetSignableCancelOrderRequest,
   ) {
-    return cancelOrderWorkflowWithSigner({
+    return cancelOrderWorkflow({
       ...walletConnection,
       request,
       ordersApi: this.ordersApi,
     });
   }
 
-  /** @deprecated */
   public createTrade(
-    signer: Signer,
-    starkWallet: StarkWallet,
-    request: GetSignableTradeRequest,
-  ) {
-    return createTradeWorkflow(signer, starkWallet, request, this.tradesApi);
-  }
-
-  public createTradeWithSigner(
     walletConnection: WalletConnection,
     request: GetSignableTradeRequest,
   ) {
-    return createTradeWorkflowWithSigner({
+    return createTradeWorkflow({
       ...walletConnection,
       request,
       tradesApi: this.tradesApi,


### PR DESCRIPTION
# Summary
### Removed
- Removed the deprecated `registerOffchain` method
- Removed the deprecated `isRegisteredOnchain` method
- Removed the deprecated `transfer` method
- Removed the deprecated `batchNftTransfer` method
- Removed the deprecated `burn` method
- Removed the deprecated `prepareWithdrawal` method
- Removed the deprecated `createOrder` method
- Removed the deprecated `cancelOrder` method
- Removed the deprecated `createTrade` method

### Changed
- Renamed the `registerOffchainWithSigner` method to `registerOffchain`
- Renamed the `isRegisteredOnchainWithSigner` method to `isRegisteredOnchain`
- Renamed the `transferWithSigner` method to `transfer`
- Renamed the `batchNftTransferWithSigner` method to `batchNftTransfer`
- Renamed the `burnWithSigner` method to `burn`
- Renamed the `prepareWithdrawalWithSigner` method to `prepareWithdrawal`
- Renamed the `createOrderWithSigner` method to `createOrder`
- Renamed the `cancelOrderWithSigner` method to `cancelOrder`
- Renamed the `createTradeWithSigner` method to `createTrade`

# Why the changes
This is the last step to accomplish the Core SDK compatibility adaptation to the Wallets SDK

# Things worth calling out
Equivalent PR on **imx-testing**: https://github.com/immutable/imx-testing/pull/82 