### PR TITLE
Changed L2Signer interface to enable async getAddress implementations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [BREAKING CHANGE] Renamed the `cancelOrderWithSigner` method to `cancelOrder`
 - [BREAKING CHANGE] Renamed the `createTradeWithSigner` method to `createTrade`
 
+- Changed the `getAddress` method from the `L2Signer` interface to be able to return both `string` or async `Promise<string>`
+
 ### Removed
 
 - [BREAKING CHANGE] Removed the deprecated `registerOffchain` method

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,7 @@ export { L1Signer };
 
 export interface L2Signer {
   signMessage(message: string): Promise<string>;
-  getAddress(): string;
+  getAddress(): string | Promise<string>;
 }
 
 export interface StarkWallet {

--- a/src/workflows/registration.ts
+++ b/src/workflows/registration.ts
@@ -58,10 +58,10 @@ export async function registerOffchainWorkflow({
 }
 
 export async function isRegisteredOnChainWorkflow(
-  starkPublicKey: string | Promise<string>,
+  starkPublicKey: string,
   contract: Registration,
 ): Promise<boolean> {
-  return await contract.isRegistered(await starkPublicKey);
+  return await contract.isRegistered(starkPublicKey);
 }
 
 export async function getSignableRegistrationOnchain(

--- a/src/workflows/registration.ts
+++ b/src/workflows/registration.ts
@@ -25,7 +25,7 @@ export async function registerOffchainWorkflow({
   usersApi,
 }: registerOffchainWorkflowParams): Promise<void> {
   const userAddress = await l1Signer.getAddress();
-  const starkPublicKey = l2Signer.getAddress();
+  const starkPublicKey = await l2Signer.getAddress();
 
   if (await isUserRegistered(userAddress, usersApi)) {
     return;
@@ -58,10 +58,10 @@ export async function registerOffchainWorkflow({
 }
 
 export async function isRegisteredOnChainWorkflow(
-  starkPublicKey: string,
+  starkPublicKey: string | Promise<string>,
   contract: Registration,
 ): Promise<boolean> {
-  return await contract.isRegistered(starkPublicKey);
+  return await contract.isRegistered(await starkPublicKey);
 }
 
 export async function getSignableRegistrationOnchain(

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -85,16 +85,15 @@ export class Workflows {
     });
   }
 
-  public isRegisteredOnchain(walletConnection: WalletConnection) {
+  public async isRegisteredOnchain(walletConnection: WalletConnection) {
     const registrationContract = Registration__factory.connect(
       this.config.registrationContractAddress,
       walletConnection.l1Signer,
     );
 
-    return isRegisteredOnChainWorkflow(
-      walletConnection.l2Signer.getAddress(),
-      registrationContract,
-    );
+    const l2Address = await walletConnection.l2Signer.getAddress();
+
+    return isRegisteredOnChainWorkflow(l2Address, registrationContract);
   }
 
   public mint(signer: Signer, request: UnsignedMintRequest) {


### PR DESCRIPTION
# Summary
Changing the `L2Signer.getAddress` interface method to enable async implementations  


# Why the changes
[We detected](https://immutable.atlassian.net/browse/WT-614) that it could be confusing for the partner which is integrating, to use getAddress methods in different ways regarding L1 and L2.

Today when the partner is integrating, and it is needed to retrieve L1 and L2 addresses, the following is done:
```ts
const walletConnection = [... Setting up and getting the connection obj from the Wallets SDK]

const l1Address = await walletConnection.l1Signer.getAddress();
const l1Address = walletConnection.l2Signer.getAddress();
```

We think the behaviour ideally should be the same, so we are changing that to: 
```ts
const walletConnection = [... Setting up and getting the connection obj from the Wallets SDK]

const l1Address = await walletConnection.l1Signer.getAddress();
const l1Address = await walletConnection.l2Signer.getAddress();
```
# Things worth mentioning
e2e tests were checked and weren't impacted