### PR TITLE
Adding the network into the configurations object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [BREAKING CHANGE] Renamed the `createTradeWithSigner` method to `createTrade`
 
 - Changed the `getAddress` method from the `L2Signer` interface to be able to return both `string` or async `Promise<string>`
+- Adding the chain (`network` property) into the `Config` interface
 
 ### Removed
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,7 @@ export type EthNetwork = 'dev' | 'ropsten' | 'mainnet';
 
 export interface Config {
   api: Configuration;
+  network: EthNetwork;
   starkContractAddress: string;
   registrationContractAddress: string;
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -23,41 +23,35 @@ export const getConfig = (
   network: EthNetwork = 'ropsten',
   apiConfigOptions: ConfigurationParameters = {},
 ): Config => {
-  switch (network) {
-    case 'dev':
-      return {
-        api: new Configuration(
-          mergeApiProperties(
-            'https://api.dev.x.immutable.com',
-            apiConfigOptions,
-          ),
+  const configs = {
+    ['dev']: {
+      api: new Configuration(
+        mergeApiProperties('https://api.dev.x.immutable.com', apiConfigOptions),
+      ),
+      starkContractAddress: '0xd05323731807A35599BF9798a1DE15e89d6D6eF1',
+      registrationContractAddress: '0x7EB840223a3b1E0e8D54bF8A6cd83df5AFfC88B2',
+    },
+    ['ropsten']: {
+      api: new Configuration(
+        mergeApiProperties(
+          'https://api.ropsten.x.immutable.com',
+          apiConfigOptions,
         ),
-        starkContractAddress: '0xd05323731807A35599BF9798a1DE15e89d6D6eF1',
-        registrationContractAddress:
-          '0x7EB840223a3b1E0e8D54bF8A6cd83df5AFfC88B2',
-      };
+      ),
+      starkContractAddress: '0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef',
+      registrationContractAddress: '0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864',
+    },
+    ['mainnet']: {
+      api: new Configuration(
+        mergeApiProperties('https://api.x.immutable.com', apiConfigOptions),
+      ),
+      starkContractAddress: '0x5FDCCA53617f4d2b9134B29090C87D01058e27e9',
+      registrationContractAddress: '0x72a06bf2a1CE5e39cBA06c0CAb824960B587d64c',
+    },
+  };
 
-    case 'ropsten':
-      return {
-        api: new Configuration(
-          mergeApiProperties(
-            'https://api.ropsten.x.immutable.com',
-            apiConfigOptions,
-          ),
-        ),
-        starkContractAddress: '0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef',
-        registrationContractAddress:
-          '0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864',
-      };
-
-    case 'mainnet':
-      return {
-        api: new Configuration(
-          mergeApiProperties('https://api.x.immutable.com', apiConfigOptions),
-        ),
-        starkContractAddress: '0x5FDCCA53617f4d2b9134B29090C87D01058e27e9',
-        registrationContractAddress:
-          '0x72a06bf2a1CE5e39cBA06c0CAb824960B587d64c',
-      };
-  }
+  return {
+    network,
+    ...configs[network],
+  };
 };


### PR DESCRIPTION
# Summary
This is the 1st part of the network validation when running workflows. First of all, we need the network to be kept in the configuration that we use to build the workflow class.


# Why the changes
An earlier network check is needed to improve security and user experience, providing better feedback when the Core SDK has one network configured, and a workflow method is called to hit a contract from another network.

# Things worth calling out
More information can be obtained through https://immutable.atlassian.net/browse/WT-430

