### PR TITLE
refactor: config is no longer hardcoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 
+- [BREAKING CHANGE] `getConfig` method now requires environment parameters and returns the new [ImmutableXConfiguration](https://github.com/immutable/imx-core-sdk/blob/cf33110d1dc6503c1e747dfced4fff0ec57bb536/src/types/index.ts#L35)
 - [BREAKING CHANGE] Renamed the `registerOffchainWithSigner` method to `registerOffchain`
 - [BREAKING CHANGE] Renamed the `isRegisteredOnchainWithSigner` method to `isRegisteredOnchain`
 - [BREAKING CHANGE] Renamed the `transferWithSigner` method to `transfer`

--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ Check out how the [Release Process](https://github.com/immutable/imx-core-sdk/#r
 
 ### Configuration
 
-A configuration object is required to be passed into Core SDK requests. This can be obtained by using the `getConfig` function available within the Core SDK. You are required to select the Ethereum network. The Immutable X platform currently supports `ropsten` for testing and `mainnet` for production.
+A configuration object is required to be passed into Core SDK requests. This can be obtained by using the `getConfig` function available within the Core SDK. You are required to provide the correct contract addresses and api base path of the network you wish to use. The Immutable X platform currently supports `ropsten` for testing and `mainnet` for production.
+
+| Network   | API Base Path                       | Stark Contract Address                       | Registration Contract Address                |
+|-----------|-------------------------------------|----------------------------------------------|----------------------------------------------|
+| `ropsten` | https://api.ropsten.x.immutable.com | `0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef` | `0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864` |
+| `mainnet` | https://api.x.immutable.com         | `0x5FDCCA53617f4d2b9134B29090C87D01058e27e9` | `0x72a06bf2a1CE5e39cBA06c0CAb824960B587d64c` |
+
 
 ```ts
 import { AlchemyProvider } from '@ethersproject/providers';
@@ -64,7 +70,13 @@ import { getConfig } from '@imtbl/core-sdk';
 const ethNetwork = 'ropsten'; // or mainnet;
 
 // Use the helper function to get the config
-const config = getConfig(ethNetwork);
+const config = getConfig({
+  starkContractAddress: '0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef',
+  registrationContractAddress: '0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864',
+  apiConfigOptions: {
+    basePath:  'https://api.ropsten.x.immutable.com',
+  },
+});
 
 // Setup a provider and a signer
 const privateKey = YOUR_PRIVATE_KEY;

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Check out how the [Release Process](https://github.com/immutable/imx-core-sdk/#r
 
 A configuration object is required to be passed into Core SDK requests. This can be obtained by using the `getConfig` function available within the Core SDK. You are required to provide the correct contract addresses and api base path of the network you wish to use. The Immutable X platform currently supports `ropsten` for testing and `mainnet` for production.
 
-| Network   | API Base Path                       | Stark Contract Address                       | Registration Contract Address                |
-|-----------|-------------------------------------|----------------------------------------------|----------------------------------------------|
-| `ropsten` | https://api.ropsten.x.immutable.com | `0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef` | `0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864` |
-| `mainnet` | https://api.x.immutable.com         | `0x5FDCCA53617f4d2b9134B29090C87D01058e27e9` | `0x72a06bf2a1CE5e39cBA06c0CAb824960B587d64c` |
+| Network   | Chain ID | API Base Path                       | Stark Contract Address                       | Registration Contract Address                |
+|-----------|----------|-------------------------------------|----------------------------------------------|----------------------------------------------|
+| `ropsten` | 3        | https://api.ropsten.x.immutable.com | `0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef` | `0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864` |
+| `mainnet` | 1        | https://api.x.immutable.com         | `0x5FDCCA53617f4d2b9134B29090C87D01058e27e9` | `0x72a06bf2a1CE5e39cBA06c0CAb824960B587d64c` |
 
 
 ```ts
@@ -73,6 +73,7 @@ const ethNetwork = 'ropsten'; // or mainnet;
 const config = getConfig({
   starkContractAddress: '0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef',
   registrationContractAddress: '0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864',
+  chainID: 3,
   apiConfigOptions: {
     basePath:  'https://api.ropsten.x.immutable.com',
   },

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Check out how the [Release Process](https://github.com/immutable/imx-core-sdk/#r
 
 ### Configuration
 
-A configuration object is required to be passed into Core SDK requests. This can be obtained by using the `getConfig` function available within the Core SDK. You are required to provide the correct contract addresses and api base path of the network you wish to use. The Immutable X platform currently supports `ropsten` for testing and `mainnet` for production.
+A configuration object is required to be passed into Core SDK requests. This can be obtained by using the `getConfig` function available within the Core SDK. You are required to provide the correct contract addresses, Chain ID, and api base path of the network you wish to use. The Immutable X platform currently supports `ropsten` for testing and `mainnet` for production.
 
 | Network   | Chain ID | API Base Path                       | Stark Contract Address                       | Registration Contract Address                |
 |-----------|----------|-------------------------------------|----------------------------------------------|----------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -74,9 +74,8 @@ const config = getConfig({
   coreContractAddress: '0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef',
   registrationContractAddress: '0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864',
   chainID: 3,
-  apiConfigOptions: {
-    basePath:  'https://api.ropsten.x.immutable.com',
-  },
+  basePath:  'https://api.ropsten.x.immutable.com',
+  headers: { 'x-api-custom-header': '...' } // headers are optional unless specified otherwise
 });
 
 // Setup a provider and a signer
@@ -119,8 +118,13 @@ The Core SDK includes classes that interact with the Immutable X APIs.
 import { getConfig, AssetsApi } from '@imtbl/core-sdk';
 
 const getYourAsset = async (tokenAddress: string, tokenId: string) => {
-  const config = getConfig('ropsten');
-  const assetsApi = new AssetsApi(config.api);
+  const config = getConfig({
+    coreContractAddress: '0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef',
+    registrationContractAddress: '0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864',
+    chainID: 3,
+    basePath:  'https://api.ropsten.x.immutable.com',
+  });
+  const assetsApi = new AssetsApi(config.apiConfiguration);
 
   const response = await assetsApi.getAsset({
     tokenAddress,
@@ -248,7 +252,12 @@ const l2Wallet = await generateStarkWallet(l1Signer);
 const l2Signer = new BaseSigner(l2Wallet.starkKeyPair);
 
 // Sets up the Core SDK workflows
-const coreSdkConfig = getConfig(ethNetwork);
+const coreSdkConfig = getConfig({
+  coreContractAddress: '0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef',
+  registrationContractAddress: '0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864',
+  chainID: 3,
+  basePath:  'https://api.ropsten.x.immutable.com',
+});
 const coreSdkWorkflows = new Workflows(coreSdkConfig);
 
 // Registers the user

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Check out how the [Release Process](https://github.com/immutable/imx-core-sdk/#r
 
 A configuration object is required to be passed into Core SDK requests. This can be obtained by using the `getConfig` function available within the Core SDK. You are required to provide the correct contract addresses, Chain ID, and api base path of the network you wish to use. The Immutable X platform currently supports `ropsten` for testing and `mainnet` for production.
 
-| Network   | Chain ID | API Base Path                       | Stark Contract Address                       | Registration Contract Address                |
+| Network   | Chain ID | API Base Path                       | Core Contract Address                        | Registration Contract Address                |
 |-----------|----------|-------------------------------------|----------------------------------------------|----------------------------------------------|
 | `ropsten` | 3        | https://api.ropsten.x.immutable.com | `0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef` | `0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864` |
 | `mainnet` | 1        | https://api.x.immutable.com         | `0x5FDCCA53617f4d2b9134B29090C87D01058e27e9` | `0x72a06bf2a1CE5e39cBA06c0CAb824960B587d64c` |
@@ -71,7 +71,7 @@ const ethNetwork = 'ropsten'; // or mainnet;
 
 // Use the helper function to get the config
 const config = getConfig({
-  starkContractAddress: '0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef',
+  coreContractAddress: '0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef',
   registrationContractAddress: '0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864',
   chainID: 3,
   apiConfigOptions: {
@@ -202,7 +202,7 @@ The Core SDK provides interfaces for all smart contracts required to interact wi
 import { Core__factory } from '@imtbl/core-sdk';
 
 // Get instance of core contract
-const contract = Core__factory.connect(config.starkContractAddress, signer);
+const contract = Core__factory.connect(config.coreContractAddress, signer);
 
 // Obtain necessary parameters...
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,8 +26,6 @@ export interface WalletConnection {
   l2Signer: L2Signer;
 }
 
-export type EthNetwork = 'dev' | 'ropsten' | 'mainnet';
-
 export interface Config {
   api: Configuration;
   starkContractAddress: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,7 +28,7 @@ export interface WalletConnection {
 
 export interface Config {
   api: Configuration;
-  starkContractAddress: string;
+  coreContractAddress: string;
   registrationContractAddress: string;
   chainID: number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,7 @@ import {
   MintRequest,
   GetSignableTransferRequestV1,
   GetSignableTransferRequest,
-  Configuration,
+  Configuration as APIConfiguration,
 } from '../api';
 import { GetSignableBurnRequest } from '../workflows/types';
 import { Signer as L1Signer } from '@ethersproject/abstract-signer';
@@ -26,11 +26,15 @@ export interface WalletConnection {
   l2Signer: L2Signer;
 }
 
-export interface Config {
-  api: Configuration;
+export interface L1Configuration {
   coreContractAddress: string;
   registrationContractAddress: string;
   chainID: number;
+}
+
+export interface ImmutableXConfiguration {
+  apiConfiguration: APIConfiguration;
+  l1Configuration: L1Configuration;
 }
 
 export type UnsignedMintRequest = Omit<MintRequest, 'auth_signature'>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,7 @@ export interface Config {
   api: Configuration;
   starkContractAddress: string;
   registrationContractAddress: string;
+  chainID: number;
 }
 
 export type UnsignedMintRequest = Omit<MintRequest, 'auth_signature'>;

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -7,7 +7,7 @@ describe('getConfig', () => {
   it('should throw if basePath is whitespace', () => {
     expect(() =>
       getConfig({
-        starkContractAddress: '0x1',
+        coreContractAddress: '0x1',
         registrationContractAddress: '0x2',
         chainID: 3,
         apiConfigOptions: { basePath: ' ' },
@@ -18,7 +18,7 @@ describe('getConfig', () => {
   it('should throw if basePath is empty', () => {
     expect(() =>
       getConfig({
-        starkContractAddress: '0x1',
+        coreContractAddress: '0x1',
         registrationContractAddress: '0x2',
         chainID: 3,
         apiConfigOptions: { basePath: '' },
@@ -28,7 +28,7 @@ describe('getConfig', () => {
 
   it('should return config', () => {
     const basePath = 'https://api.ropsten.x.immutable.com';
-    const starkContractAddress = '0x1';
+    const coreContractAddress = '0x1';
     const registrationContractAddress = '0x2';
     const chainID = 3;
     const customHeaders = { 'x-custom-headers': 'x values' };
@@ -40,12 +40,12 @@ describe('getConfig', () => {
         },
       },
       chainID,
-      starkContractAddress,
+      coreContractAddress,
       registrationContractAddress,
     };
 
     const actual = getConfig({
-      starkContractAddress,
+      coreContractAddress,
       registrationContractAddress,
       chainID,
       apiConfigOptions: {

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -1,5 +1,7 @@
 import { getConfig } from './config';
 import { version } from '../../package.json';
+import { ImmutableXConfiguration } from '../types';
+import { Configuration } from '../api';
 
 const defaultHeaders = { 'x-sdk-version': `imx-core-sdk-ts-${version}` };
 
@@ -10,9 +12,9 @@ describe('getConfig', () => {
         coreContractAddress: '0x1',
         registrationContractAddress: '0x2',
         chainID: 3,
-        apiConfigOptions: { basePath: ' ' },
+        basePath: ' ',
       }),
-    ).toThrowError('apiConfigOptions.basePath can not be empty');
+    ).toThrowError('basePath can not be empty');
   });
 
   it('should throw if basePath is empty', () => {
@@ -21,9 +23,9 @@ describe('getConfig', () => {
         coreContractAddress: '0x1',
         registrationContractAddress: '0x2',
         chainID: 3,
-        apiConfigOptions: { basePath: '' },
+        basePath: '',
       }),
-    ).toThrowError('apiConfigOptions.basePath can not be empty');
+    ).toThrowError('basePath can not be empty');
   });
 
   it('should return config', () => {
@@ -32,26 +34,26 @@ describe('getConfig', () => {
     const registrationContractAddress = '0x2';
     const chainID = 3;
     const customHeaders = { 'x-custom-headers': 'x values' };
-    const expected = {
-      api: {
+    const expected: ImmutableXConfiguration = {
+      apiConfiguration: new Configuration({
         basePath,
         baseOptions: {
           headers: { ...customHeaders, ...defaultHeaders },
         },
+      }),
+      l1Configuration: {
+        chainID,
+        coreContractAddress,
+        registrationContractAddress,
       },
-      chainID,
-      coreContractAddress,
-      registrationContractAddress,
     };
 
     const actual = getConfig({
       coreContractAddress,
       registrationContractAddress,
       chainID,
-      apiConfigOptions: {
-        basePath,
-        baseOptions: { headers: customHeaders },
-      },
+      basePath,
+      headers: customHeaders,
     });
     expect(actual).toEqual(expected);
   });

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -33,12 +33,15 @@ describe('getConfig', () => {
     const coreContractAddress = '0x1';
     const registrationContractAddress = '0x2';
     const chainID = 3;
-    const customHeaders = { 'x-custom-headers': 'x values' };
+    const customHeaders = {
+      'x-custom-headers': 'x values',
+      'x-sdk-version': 'this should get overwritten',
+    };
     const expected: ImmutableXConfiguration = {
       apiConfiguration: new Configuration({
         basePath,
         baseOptions: {
-          headers: { ...customHeaders, ...defaultHeaders },
+          headers: { 'x-custom-headers': 'x values', ...defaultHeaders },
         },
       }),
       l1Configuration: {

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -9,6 +9,7 @@ describe('getConfig', () => {
       getConfig({
         starkContractAddress: '0x1',
         registrationContractAddress: '0x2',
+        chainID: 3,
         apiConfigOptions: { basePath: ' ' },
       }),
     ).toThrowError('apiConfigOptions.basePath can not be empty');
@@ -19,6 +20,7 @@ describe('getConfig', () => {
       getConfig({
         starkContractAddress: '0x1',
         registrationContractAddress: '0x2',
+        chainID: 3,
         apiConfigOptions: { basePath: '' },
       }),
     ).toThrowError('apiConfigOptions.basePath can not be empty');
@@ -28,6 +30,7 @@ describe('getConfig', () => {
     const basePath = 'https://api.ropsten.x.immutable.com';
     const starkContractAddress = '0x1';
     const registrationContractAddress = '0x2';
+    const chainID = 3;
     const customHeaders = { 'x-custom-headers': 'x values' };
     const expected = {
       api: {
@@ -36,6 +39,7 @@ describe('getConfig', () => {
           headers: { ...customHeaders, ...defaultHeaders },
         },
       },
+      chainID,
       starkContractAddress,
       registrationContractAddress,
     };
@@ -43,6 +47,7 @@ describe('getConfig', () => {
     const actual = getConfig({
       starkContractAddress,
       registrationContractAddress,
+      chainID,
       apiConfigOptions: {
         basePath,
         baseOptions: { headers: customHeaders },

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -1,0 +1,53 @@
+import { getConfig } from './config';
+import { version } from '../../package.json';
+
+const defaultHeaders = { 'x-sdk-version': `imx-core-sdk-ts-${version}` };
+
+describe('getConfig', () => {
+  it('should throw if basePath is whitespace', () => {
+    expect(() =>
+      getConfig({
+        starkContractAddress: '0x1',
+        registrationContractAddress: '0x2',
+        apiConfigOptions: { basePath: ' ' },
+      }),
+    ).toThrowError('apiConfigOptions.basePath can not be empty');
+  });
+
+  it('should throw if basePath is empty', () => {
+    expect(() =>
+      getConfig({
+        starkContractAddress: '0x1',
+        registrationContractAddress: '0x2',
+        apiConfigOptions: { basePath: '' },
+      }),
+    ).toThrowError('apiConfigOptions.basePath can not be empty');
+  });
+
+  it('should return config', () => {
+    const basePath = 'https://api.ropsten.x.immutable.com';
+    const starkContractAddress = '0x1';
+    const registrationContractAddress = '0x2';
+    const customHeaders = { 'x-custom-headers': 'x values' };
+    const expected = {
+      api: {
+        basePath,
+        baseOptions: {
+          headers: { ...customHeaders, ...defaultHeaders },
+        },
+      },
+      starkContractAddress,
+      registrationContractAddress,
+    };
+
+    const actual = getConfig({
+      starkContractAddress,
+      registrationContractAddress,
+      apiConfigOptions: {
+        basePath,
+        baseOptions: { headers: customHeaders },
+      },
+    });
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -19,14 +19,14 @@ const appendDefaultHeaders = (
 };
 
 interface ConfigParams {
-  starkContractAddress: string;
+  coreContractAddress: string;
   registrationContractAddress: string;
   chainID: number;
   apiConfigOptions: RequiredProperties<ConfigurationParameters, 'basePath'>;
 }
 
 export const getConfig = ({
-  starkContractAddress,
+  coreContractAddress,
   registrationContractAddress,
   chainID,
   apiConfigOptions,
@@ -37,7 +37,7 @@ export const getConfig = ({
   appendDefaultHeaders(apiConfigOptions);
   return {
     api: new Configuration(apiConfigOptions),
-    starkContractAddress,
+    coreContractAddress,
     registrationContractAddress,
     chainID,
   };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,11 +1,8 @@
 import { Configuration, ConfigurationParameters } from '../api';
-import { Config } from '../types';
+import { ImmutableXConfiguration, L1Configuration } from '../types';
 import { version } from '../../package.json';
 
 const defaultHeaders = { 'x-sdk-version': `imx-core-sdk-ts-${version}` };
-
-type RequiredProperties<T, P extends keyof T> = Omit<T, P> &
-  Required<Pick<T, P>>;
 
 const appendDefaultHeaders = (
   apiConfigOptions: ConfigurationParameters,
@@ -18,27 +15,31 @@ const appendDefaultHeaders = (
   return apiConfigOptions;
 };
 
-interface ConfigParams {
-  coreContractAddress: string;
-  registrationContractAddress: string;
-  chainID: number;
-  apiConfigOptions: RequiredProperties<ConfigurationParameters, 'basePath'>;
+interface Environment extends L1Configuration {
+  basePath: string;
+  headers?: Record<string, string>;
 }
 
 export const getConfig = ({
   coreContractAddress,
   registrationContractAddress,
   chainID,
-  apiConfigOptions,
-}: ConfigParams): Config => {
-  if (!apiConfigOptions.basePath?.trim()) {
-    throw Error('apiConfigOptions.basePath can not be empty');
+  basePath,
+  headers,
+}: Environment): ImmutableXConfiguration => {
+  if (!basePath.trim()) {
+    throw Error('basePath can not be empty');
   }
-  appendDefaultHeaders(apiConfigOptions);
+  const apiConfigOptions = appendDefaultHeaders({
+    basePath,
+    baseOptions: { headers: headers || {} },
+  });
   return {
-    api: new Configuration(apiConfigOptions),
-    coreContractAddress,
-    registrationContractAddress,
-    chainID,
+    apiConfiguration: new Configuration(apiConfigOptions),
+    l1Configuration: {
+      coreContractAddress,
+      registrationContractAddress,
+      chainID,
+    },
   };
 };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -21,12 +21,14 @@ const appendDefaultHeaders = (
 interface ConfigParams {
   starkContractAddress: string;
   registrationContractAddress: string;
+  chainID: number;
   apiConfigOptions: RequiredProperties<ConfigurationParameters, 'basePath'>;
 }
 
 export const getConfig = ({
   starkContractAddress,
   registrationContractAddress,
+  chainID,
   apiConfigOptions,
 }: ConfigParams): Config => {
   if (!apiConfigOptions.basePath?.trim()) {
@@ -37,5 +39,6 @@ export const getConfig = ({
     api: new Configuration(apiConfigOptions),
     starkContractAddress,
     registrationContractAddress,
+    chainID,
   };
 };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,63 +1,40 @@
 import { Configuration, ConfigurationParameters } from '../api';
-import { Config, EthNetwork } from '../types';
+import { Config } from '../types';
 import { version } from '../../package.json';
 
-const headers = { 'x-sdk-version': `imx-core-sdk-ts-${version}` };
+const defaultHeaders = { 'x-sdk-version': `imx-core-sdk-ts-${version}` };
 
-const mergeApiProperties = (
-  basePath: string,
-  apiConfigOptions: ConfigurationParameters,
-) => ({
-  basePath,
-  ...apiConfigOptions,
-  baseOptions: {
-    ...(apiConfigOptions.baseOptions || {}),
-    headers: {
-      ...(apiConfigOptions.baseOptions?.headers || {}),
-      ...headers,
-    },
-  },
-});
+type RequiredProperties<T, P extends keyof T> = Omit<T, P> & Required<Pick<T, P>>;
 
-export const getConfig = (
-  network: EthNetwork = 'ropsten',
-  apiConfigOptions: ConfigurationParameters = {},
-): Config => {
-  switch (network) {
-    case 'dev':
-      return {
-        api: new Configuration(
-          mergeApiProperties(
-            'https://api.dev.x.immutable.com',
-            apiConfigOptions,
-          ),
-        ),
-        starkContractAddress: '0xd05323731807A35599BF9798a1DE15e89d6D6eF1',
-        registrationContractAddress:
-          '0x7EB840223a3b1E0e8D54bF8A6cd83df5AFfC88B2',
-      };
+interface ConfigParams {
+  starkContractAddress: string;
+  registrationContractAddress: string;
+  apiConfigOptions: RequiredProperties<ConfigurationParameters, 'basePath'>;
+}
 
-    case 'ropsten':
-      return {
-        api: new Configuration(
-          mergeApiProperties(
-            'https://api.ropsten.x.immutable.com',
-            apiConfigOptions,
-          ),
-        ),
-        starkContractAddress: '0x4527BE8f31E2ebFbEF4fCADDb5a17447B27d2aef',
-        registrationContractAddress:
-          '0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864',
-      };
-
-    case 'mainnet':
-      return {
-        api: new Configuration(
-          mergeApiProperties('https://api.x.immutable.com', apiConfigOptions),
-        ),
-        starkContractAddress: '0x5FDCCA53617f4d2b9134B29090C87D01058e27e9',
-        registrationContractAddress:
-          '0x72a06bf2a1CE5e39cBA06c0CAb824960B587d64c',
-      };
+export const getConfig = ({
+  starkContractAddress,
+  registrationContractAddress,
+  apiConfigOptions,
+}: ConfigParams): Config => {
+  if (!apiConfigOptions.basePath?.trim()) {
+    throw Error('apiConfigOptions.basePath can not be empty');
   }
+  appendDefaultHeaders(apiConfigOptions);
+  return {
+    api: new Configuration(apiConfigOptions),
+    starkContractAddress,
+    registrationContractAddress,
+  };
+};
+
+const appendDefaultHeaders = (
+  apiConfigOptions: ConfigurationParameters,
+): ConfigurationParameters => {
+  apiConfigOptions.baseOptions = apiConfigOptions.baseOptions || {};
+  apiConfigOptions.baseOptions.headers = {
+    ...(apiConfigOptions.baseOptions.headers || {}),
+    ...defaultHeaders,
+  };
+  return apiConfigOptions;
 };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -4,17 +4,6 @@ import { version } from '../../package.json';
 
 const defaultHeaders = { 'x-sdk-version': `imx-core-sdk-ts-${version}` };
 
-const appendDefaultHeaders = (
-  apiConfigOptions: ConfigurationParameters,
-): ConfigurationParameters => {
-  apiConfigOptions.baseOptions = apiConfigOptions.baseOptions || {};
-  apiConfigOptions.baseOptions.headers = {
-    ...(apiConfigOptions.baseOptions.headers || {}),
-    ...defaultHeaders,
-  };
-  return apiConfigOptions;
-};
-
 interface Environment extends L1Configuration {
   basePath: string;
   headers?: Record<string, string>;
@@ -30,10 +19,13 @@ export const getConfig = ({
   if (!basePath.trim()) {
     throw Error('basePath can not be empty');
   }
-  const apiConfigOptions = appendDefaultHeaders({
+
+  headers = { ...(headers || {}), ...defaultHeaders };
+  const apiConfigOptions: ConfigurationParameters = {
     basePath,
-    baseOptions: { headers: headers || {} },
-  });
+    baseOptions: { headers },
+  };
+
   return {
     apiConfiguration: new Configuration(apiConfigOptions),
     l1Configuration: {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -4,7 +4,19 @@ import { version } from '../../package.json';
 
 const defaultHeaders = { 'x-sdk-version': `imx-core-sdk-ts-${version}` };
 
-type RequiredProperties<T, P extends keyof T> = Omit<T, P> & Required<Pick<T, P>>;
+type RequiredProperties<T, P extends keyof T> = Omit<T, P> &
+  Required<Pick<T, P>>;
+
+const appendDefaultHeaders = (
+  apiConfigOptions: ConfigurationParameters,
+): ConfigurationParameters => {
+  apiConfigOptions.baseOptions = apiConfigOptions.baseOptions || {};
+  apiConfigOptions.baseOptions.headers = {
+    ...(apiConfigOptions.baseOptions.headers || {}),
+    ...defaultHeaders,
+  };
+  return apiConfigOptions;
+};
 
 interface ConfigParams {
   starkContractAddress: string;
@@ -26,15 +38,4 @@ export const getConfig = ({
     starkContractAddress,
     registrationContractAddress,
   };
-};
-
-const appendDefaultHeaders = (
-  apiConfigOptions: ConfigurationParameters,
-): ConfigurationParameters => {
-  apiConfigOptions.baseOptions = apiConfigOptions.baseOptions || {};
-  apiConfigOptions.baseOptions.headers = {
-    ...(apiConfigOptions.baseOptions.headers || {}),
-    ...defaultHeaders,
-  };
-  return apiConfigOptions;
 };

--- a/src/workflows/deposit/depositERC20.ts
+++ b/src/workflows/deposit/depositERC20.ts
@@ -93,7 +93,7 @@ export async function depositERC20Workflow(
   // Approve whether an amount of token from an account can be spent by a third-party account
   const tokenContract = IERC20__factory.connect(deposit.tokenAddress, signer);
   const approveTransaction = await tokenContract.populateTransaction.approve(
-    config.starkContractAddress,
+    config.coreContractAddress,
     amount,
   );
   await signer.sendTransaction(approveTransaction);
@@ -130,7 +130,7 @@ export async function depositERC20Workflow(
   const quantizedAmount = BigNumber.from(signableDepositResult.data.amount);
 
   const coreContract = Core__factory.connect(
-    config.starkContractAddress,
+    config.coreContractAddress,
     signer,
   );
 

--- a/src/workflows/deposit/depositERC20.ts
+++ b/src/workflows/deposit/depositERC20.ts
@@ -12,7 +12,7 @@ import {
   getSignableRegistrationOnchain,
   isRegisteredOnChainWorkflow,
 } from '../registration';
-import { Config, ERC20Deposit } from '../../types';
+import { ImmutableXConfiguration, ERC20Deposit } from '../../types';
 import { BigNumber } from '@ethersproject/bignumber';
 
 interface ERC20TokenData {
@@ -75,7 +75,7 @@ export async function depositERC20Workflow(
   usersApi: UsersApi,
   tokensApi: TokensApi,
   encodingApi: EncodingApi,
-  config: Config,
+  config: ImmutableXConfiguration,
 ): Promise<TransactionResponse> {
   const user = await signer.getAddress();
 
@@ -93,7 +93,7 @@ export async function depositERC20Workflow(
   // Approve whether an amount of token from an account can be spent by a third-party account
   const tokenContract = IERC20__factory.connect(deposit.tokenAddress, signer);
   const approveTransaction = await tokenContract.populateTransaction.approve(
-    config.coreContractAddress,
+    config.l1Configuration.coreContractAddress,
     amount,
   );
   await signer.sendTransaction(approveTransaction);
@@ -130,12 +130,12 @@ export async function depositERC20Workflow(
   const quantizedAmount = BigNumber.from(signableDepositResult.data.amount);
 
   const coreContract = Core__factory.connect(
-    config.coreContractAddress,
+    config.l1Configuration.coreContractAddress,
     signer,
   );
 
   const registrationContract = Registration__factory.connect(
-    config.registrationContractAddress,
+    config.l1Configuration.registrationContractAddress,
     signer,
   );
 

--- a/src/workflows/deposit/depositERC721.ts
+++ b/src/workflows/deposit/depositERC721.ts
@@ -88,7 +88,7 @@ export async function depositERC721Workflow(
   // Approve whether an amount of token from an account can be spent by a third-party account
   const tokenContract = IERC721__factory.connect(deposit.tokenAddress, signer);
   const approveTransaction = await tokenContract.populateTransaction.approve(
-    config.starkContractAddress,
+    config.coreContractAddress,
     deposit.tokenId,
   );
   await signer.sendTransaction(approveTransaction);
@@ -125,7 +125,7 @@ export async function depositERC721Workflow(
   const vaultId = signableDepositResult.data.vault_id;
 
   const coreContract = Core__factory.connect(
-    config.starkContractAddress,
+    config.coreContractAddress,
     signer,
   );
 

--- a/src/workflows/deposit/depositERC721.ts
+++ b/src/workflows/deposit/depositERC721.ts
@@ -12,7 +12,7 @@ import {
   getSignableRegistrationOnchain,
   isRegisteredOnChainWorkflow,
 } from '../registration';
-import { Config, ERC721Deposit } from '../../types';
+import { ImmutableXConfiguration, ERC721Deposit } from '../../types';
 
 interface ERC721TokenData {
   token_id: string;
@@ -74,7 +74,7 @@ export async function depositERC721Workflow(
   depositsApi: DepositsApi,
   usersApi: UsersApi,
   encodingApi: EncodingApi,
-  config: Config,
+  config: ImmutableXConfiguration,
 ): Promise<TransactionResponse> {
   const user = await signer.getAddress();
 
@@ -88,7 +88,7 @@ export async function depositERC721Workflow(
   // Approve whether an amount of token from an account can be spent by a third-party account
   const tokenContract = IERC721__factory.connect(deposit.tokenAddress, signer);
   const approveTransaction = await tokenContract.populateTransaction.approve(
-    config.coreContractAddress,
+    config.l1Configuration.coreContractAddress,
     deposit.tokenId,
   );
   await signer.sendTransaction(approveTransaction);
@@ -125,12 +125,12 @@ export async function depositERC721Workflow(
   const vaultId = signableDepositResult.data.vault_id;
 
   const coreContract = Core__factory.connect(
-    config.coreContractAddress,
+    config.l1Configuration.coreContractAddress,
     signer,
   );
 
   const registrationContract = Registration__factory.connect(
-    config.registrationContractAddress,
+    config.l1Configuration.registrationContractAddress,
     signer,
   );
 

--- a/src/workflows/deposit/depositEth.ts
+++ b/src/workflows/deposit/depositEth.ts
@@ -7,7 +7,7 @@ import {
   getSignableRegistrationOnchain,
   isRegisteredOnChainWorkflow,
 } from '../registration';
-import { Config, ETHDeposit } from '../../types';
+import { ImmutableXConfiguration, ETHDeposit } from '../../types';
 import { BigNumber } from '@ethersproject/bignumber';
 
 interface ETHTokenData {
@@ -64,7 +64,7 @@ export async function depositEthWorkflow(
   depositsApi: DepositsApi,
   usersApi: UsersApi,
   encodingApi: EncodingApi,
-  config: Config,
+  config: ImmutableXConfiguration,
 ): Promise<TransactionResponse> {
   const user = await signer.getAddress();
   const data: ETHTokenData = {
@@ -99,12 +99,12 @@ export async function depositEthWorkflow(
   const vaultId = signableDepositResult.data.vault_id;
 
   const coreContract = Core__factory.connect(
-    config.coreContractAddress,
+    config.l1Configuration.coreContractAddress,
     signer,
   );
 
   const registrationContract = Registration__factory.connect(
-    config.registrationContractAddress,
+    config.l1Configuration.registrationContractAddress,
     signer,
   );
 

--- a/src/workflows/deposit/depositEth.ts
+++ b/src/workflows/deposit/depositEth.ts
@@ -99,7 +99,7 @@ export async function depositEthWorkflow(
   const vaultId = signableDepositResult.data.vault_id;
 
   const coreContract = Core__factory.connect(
-    config.starkContractAddress,
+    config.coreContractAddress,
     signer,
   );
 

--- a/src/workflows/withdrawal/completeERC20Withdrawal.ts
+++ b/src/workflows/withdrawal/completeERC20Withdrawal.ts
@@ -73,7 +73,7 @@ export async function completeERC20WithdrawalWorfklow(
   );
 
   const coreContract = Core__factory.connect(
-    config.starkContractAddress,
+    config.coreContractAddress,
     signer,
   );
 

--- a/src/workflows/withdrawal/completeERC20Withdrawal.ts
+++ b/src/workflows/withdrawal/completeERC20Withdrawal.ts
@@ -7,7 +7,11 @@ import {
   Registration,
   Registration__factory,
 } from '../../contracts';
-import { Config, ERC20Withdrawal, TokenType } from '../../types';
+import {
+  ImmutableXConfiguration,
+  ERC20Withdrawal,
+  TokenType,
+} from '../../types';
 import {
   getSignableRegistrationOnchain,
   isRegisteredOnChainWorkflow,
@@ -60,7 +64,7 @@ export async function completeERC20WithdrawalWorfklow(
   token: ERC20Withdrawal,
   encodingApi: EncodingApi,
   usersApi: UsersApi,
-  config: Config,
+  config: ImmutableXConfiguration,
 ) {
   const assetType = await getEncodeAssetInfo(
     'asset',
@@ -73,12 +77,12 @@ export async function completeERC20WithdrawalWorfklow(
   );
 
   const coreContract = Core__factory.connect(
-    config.coreContractAddress,
+    config.l1Configuration.coreContractAddress,
     signer,
   );
 
   const registrationContract = Registration__factory.connect(
-    config.registrationContractAddress,
+    config.l1Configuration.registrationContractAddress,
     signer,
   );
 

--- a/src/workflows/withdrawal/completeERC721Withdrawal.ts
+++ b/src/workflows/withdrawal/completeERC721Withdrawal.ts
@@ -95,7 +95,7 @@ async function completeMintableERC721Withdrawal(
   const mintingBlob = getMintingBlob(token);
 
   const coreContract = Core__factory.connect(
-    config.starkContractAddress,
+    config.coreContractAddress,
     signer,
   );
 
@@ -191,7 +191,7 @@ async function completeERC721Withdrawal(
   );
 
   const coreContract = Core__factory.connect(
-    config.starkContractAddress,
+    config.coreContractAddress,
     signer,
   );
 

--- a/src/workflows/withdrawal/completeERC721Withdrawal.ts
+++ b/src/workflows/withdrawal/completeERC721Withdrawal.ts
@@ -7,7 +7,11 @@ import {
   Registration__factory,
 } from '../../contracts';
 import * as encUtils from 'enc-utils';
-import { Config, ERC721Withdrawal, TokenType } from '../../types';
+import {
+  ImmutableXConfiguration,
+  ERC721Withdrawal,
+  TokenType,
+} from '../../types';
 import { getEncodeAssetInfo } from './getEncodeAssetInfo';
 import {
   getSignableRegistrationOnchain,
@@ -80,7 +84,7 @@ async function completeMintableERC721Withdrawal(
   token: MintableERC721Withdrawal,
   encodingApi: EncodingApi,
   usersApi: UsersApi,
-  config: Config,
+  config: ImmutableXConfiguration,
 ) {
   const assetType = await getEncodeAssetInfo(
     'mintable-asset',
@@ -95,12 +99,12 @@ async function completeMintableERC721Withdrawal(
   const mintingBlob = getMintingBlob(token);
 
   const coreContract = Core__factory.connect(
-    config.coreContractAddress,
+    config.l1Configuration.coreContractAddress,
     signer,
   );
 
   const registrationContract = Registration__factory.connect(
-    config.registrationContractAddress,
+    config.l1Configuration.registrationContractAddress,
     signer,
   );
 
@@ -178,7 +182,7 @@ async function completeERC721Withdrawal(
   token: ERC721Withdrawal,
   encodingApi: EncodingApi,
   usersApi: UsersApi,
-  config: Config,
+  config: ImmutableXConfiguration,
 ) {
   const assetType = await getEncodeAssetInfo(
     'asset',
@@ -191,12 +195,12 @@ async function completeERC721Withdrawal(
   );
 
   const coreContract = Core__factory.connect(
-    config.coreContractAddress,
+    config.l1Configuration.coreContractAddress,
     signer,
   );
 
   const registrationContract = Registration__factory.connect(
-    config.registrationContractAddress,
+    config.l1Configuration.registrationContractAddress,
     signer,
   );
 
@@ -232,7 +236,7 @@ export async function completeERC721WithdrawalWorkflow(
   encodingApi: EncodingApi,
   mintsApi: MintsApi,
   usersApi: UsersApi,
-  config: Config,
+  config: ImmutableXConfiguration,
 ) {
   const tokenAddress = token.data.tokenAddress;
   const tokenId = token.data.tokenId;

--- a/src/workflows/withdrawal/completeEthWithdrawal.ts
+++ b/src/workflows/withdrawal/completeEthWithdrawal.ts
@@ -7,7 +7,7 @@ import {
   Registration,
   Registration__factory,
 } from '../../contracts';
-import { Config } from '../../types';
+import { ImmutableXConfiguration } from '../../types';
 import {
   getSignableRegistrationOnchain,
   isRegisteredOnChainWorkflow,
@@ -59,17 +59,17 @@ export async function completeEthWithdrawalWorkflow(
   starkPublicKey: string,
   encodingApi: EncodingApi,
   usersApi: UsersApi,
-  config: Config,
+  config: ImmutableXConfiguration,
 ) {
   const assetType = await getEncodeAssetInfo('asset', 'ETH', encodingApi);
 
   const coreContract = Core__factory.connect(
-    config.coreContractAddress,
+    config.l1Configuration.coreContractAddress,
     signer,
   );
 
   const registrationContract = Registration__factory.connect(
-    config.registrationContractAddress,
+    config.l1Configuration.registrationContractAddress,
     signer,
   );
 

--- a/src/workflows/withdrawal/completeEthWithdrawal.ts
+++ b/src/workflows/withdrawal/completeEthWithdrawal.ts
@@ -64,7 +64,7 @@ export async function completeEthWithdrawalWorkflow(
   const assetType = await getEncodeAssetInfo('asset', 'ETH', encodingApi);
 
   const coreContract = Core__factory.connect(
-    config.starkContractAddress,
+    config.coreContractAddress,
     signer,
   );
 

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -25,7 +25,7 @@ import {
   TokenDeposit,
   TokenType,
   UnsignedBurnRequest,
-  Config,
+  ImmutableXConfiguration,
   ERC721Withdrawal,
   ERC20Withdrawal,
   TokenWithdrawal,
@@ -65,17 +65,17 @@ export class Workflows {
   private readonly usersApi: UsersApi;
   private readonly withdrawalsApi: WithdrawalsApi;
 
-  constructor(protected config: Config) {
+  constructor(protected config: ImmutableXConfiguration) {
     this.config = config;
-    this.depositsApi = new DepositsApi(config.api);
-    this.encodingApi = new EncodingApi(config.api);
-    this.mintsApi = new MintsApi(config.api);
-    this.ordersApi = new OrdersApi(config.api);
-    this.tokensApi = new TokensApi(config.api);
-    this.tradesApi = new TradesApi(config.api);
-    this.transfersApi = new TransfersApi(config.api);
-    this.usersApi = new UsersApi(config.api);
-    this.withdrawalsApi = new WithdrawalsApi(config.api);
+    this.depositsApi = new DepositsApi(config.apiConfiguration);
+    this.encodingApi = new EncodingApi(config.apiConfiguration);
+    this.mintsApi = new MintsApi(config.apiConfiguration);
+    this.ordersApi = new OrdersApi(config.apiConfiguration);
+    this.tokensApi = new TokensApi(config.apiConfiguration);
+    this.tradesApi = new TradesApi(config.apiConfiguration);
+    this.transfersApi = new TransfersApi(config.apiConfiguration);
+    this.usersApi = new UsersApi(config.apiConfiguration);
+    this.withdrawalsApi = new WithdrawalsApi(config.apiConfiguration);
   }
 
   public registerOffchain(walletConnection: WalletConnection) {
@@ -87,7 +87,7 @@ export class Workflows {
 
   public async isRegisteredOnchain(walletConnection: WalletConnection) {
     const registrationContract = Registration__factory.connect(
-      this.config.registrationContractAddress,
+      this.config.l1Configuration.registrationContractAddress,
       walletConnection.l1Signer,
     );
 


### PR DESCRIPTION
# Summary
Config is not hard-coded and must be populated by user.


# Why the changes
- Internal feedback


# Things worth calling out

We might want to create a public api endpoint to fetch the Stark/Registration Contract Addresses and ChainID.
This would serve two purposes where getConfig no longer needs them as a param it can fetch from the new get contract addresses endpoint.
And it would also allow validating config.chainID -> signer.getChainId()
Having the endpoint would also mean there's one single source of truth for all the contract addresses in multiple environments. We won't have to publish them in multiple places like READMEs and imx-doc sites.

[WT-591]
[WT-430]
[DX-1019]



[DX-1019]: https://immutable.atlassian.net/browse/DX-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WT-591]: https://immutable.atlassian.net/browse/WT-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WT-430]: https://immutable.atlassian.net/browse/WT-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ