### PR TITLE
refactor: token type as string instead of enum

### DIFF
--- a/src/types/deposit.ts
+++ b/src/types/deposit.ts
@@ -1,19 +1,17 @@
-import { TokenType } from './token';
-
 export interface ETHDeposit {
-  type: TokenType.ETH;
+  type: 'ETH';
   amount: string;
 }
 
 export interface ERC20Deposit {
-  type: TokenType.ERC20;
+  type: 'ERC20';
   tokenAddress: string;
   symbol: string;
   amount: string;
 }
 
 export interface ERC721Deposit {
-  type: TokenType.ERC721;
+  type: 'ERC721';
   tokenId: string;
   tokenAddress: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,5 +35,4 @@ export type UnsignedTransferRequest = GetSignableTransferRequestV1;
 
 export * from './deposit';
 export * from './withdrawal';
-export * from './token';
 export * from './signable-withdrawal';

--- a/src/types/signable-withdrawal.ts
+++ b/src/types/signable-withdrawal.ts
@@ -1,8 +1,7 @@
 import { TokenPrepareWithdrawal } from './withdrawal';
-import { TokenType } from './token';
 
 export interface SignableWithdrawalERC20 {
-  type: TokenType.ERC20;
+  type: 'ERC20';
   data: {
     token_address: string;
     decimals: number;
@@ -10,7 +9,7 @@ export interface SignableWithdrawalERC20 {
 }
 
 export interface SignableWithdrawalERC721 {
-  type: TokenType.ERC721;
+  type: 'ERC721';
   data: {
     token_id: string;
     token_address: string;
@@ -18,7 +17,7 @@ export interface SignableWithdrawalERC721 {
 }
 
 export type SignableWithdrawalEth = {
-  type: TokenType.ETH;
+  type: 'ETH';
   data: {
     decimals: number;
   };
@@ -33,18 +32,18 @@ export type SignableWithdrawalToken =
 export function convertToSignableRequestFormat(
   token: TokenPrepareWithdrawal,
 ): SignableWithdrawalToken {
-  if (token.type === TokenType.ERC721) {
+  if (token.type === 'ERC721') {
     return {
-      type: TokenType.ERC721,
+      type: 'ERC721',
       data: {
         token_id: token.data.tokenId,
         token_address: token.data.tokenAddress,
       },
     };
   }
-  if (token.type === TokenType.ERC20) {
+  if (token.type === 'ERC20') {
     return {
-      type: TokenType.ERC20,
+      type: 'ERC20',
       data: {
         decimals: token.data.decimals,
         token_address: token.data.tokenAddress,

--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -1,5 +1,0 @@
-export enum TokenType {
-  ETH = 'ETH',
-  ERC20 = 'ERC20',
-  ERC721 = 'ERC721',
-}

--- a/src/types/withdrawal.ts
+++ b/src/types/withdrawal.ts
@@ -1,46 +1,42 @@
-import { TokenType } from './token';
-import { WalletConnection } from './index';
-import { WithdrawalsApi } from '../api';
-
 export interface ETHWithdrawal {
-  type: TokenType.ETH;
+  type: 'ETH';
 }
 
 export interface ETHPrepareWithdrawal {
-  type: TokenType.ETH;
+  type: 'ETH';
   data: {
-    decimals: number
-  }
+    decimals: number;
+  };
 }
 
 export const ETH_PREPARE_WITHDRAWAL_DATA: ETHPrepareWithdrawal = {
-  type: TokenType.ETH,
+  type: 'ETH',
   data: {
     decimals: 18,
   },
-}
+};
 
 export interface ERC721Withdrawal {
-  type: TokenType.ERC721;
+  type: 'ERC721';
   data: {
-    tokenId: string,
+    tokenId: string;
     tokenAddress: string;
   };
 }
 
 export interface ERC20Withdrawal {
-  type: TokenType.ERC20;
+  type: 'ERC20';
   data: {
-    tokenId: string,
+    tokenId: string;
     tokenAddress: string;
   };
 }
 
 export interface ERC20PrepareWithdrawal {
-  type: TokenType.ERC20;
+  type: 'ERC20';
   data: {
-    tokenAddress: string,
-    decimals: number,
+    tokenAddress: string;
+    decimals: number;
   };
 }
 
@@ -48,7 +44,7 @@ export interface ERC20PrepareWithdrawal {
 export type TokenWithdrawal = ETHWithdrawal | ERC20Withdrawal | ERC721Withdrawal;
 export type TokenPrepareWithdrawal = ETHPrepareWithdrawal | ERC20PrepareWithdrawal | ERC721Withdrawal;
 
-export type PrepareWithdrawalRequest =  {
+export type PrepareWithdrawalRequest = {
   token: TokenPrepareWithdrawal;
   quantity: string;
-}
+};

--- a/src/workflows/withdrawal/completeERC20Withdrawal.ts
+++ b/src/workflows/withdrawal/completeERC20Withdrawal.ts
@@ -7,10 +7,7 @@ import {
   Registration,
   Registration__factory,
 } from '../../contracts';
-import {
-  ImmutableXConfiguration,
-  ERC20Withdrawal,
-} from '../../types';
+import { ImmutableXConfiguration, ERC20Withdrawal } from '../../types';
 import {
   getSignableRegistrationOnchain,
   isRegisteredOnChainWorkflow,
@@ -65,15 +62,10 @@ export async function completeERC20WithdrawalWorfklow(
   usersApi: UsersApi,
   config: ImmutableXConfiguration,
 ) {
-  const assetType = await getEncodeAssetInfo(
-    'asset',
-    'ERC20',
-    encodingApi,
-    {
-      token_id: token.data.tokenId,
-      token_address: token.data.tokenAddress,
-    },
-  );
+  const assetType = await getEncodeAssetInfo('asset', 'ERC20', encodingApi, {
+    token_id: token.data.tokenId,
+    token_address: token.data.tokenAddress,
+  });
 
   const coreContract = Core__factory.connect(
     config.ethConfiguration.coreContractAddress,

--- a/src/workflows/withdrawal/completeERC20Withdrawal.ts
+++ b/src/workflows/withdrawal/completeERC20Withdrawal.ts
@@ -10,7 +10,6 @@ import {
 import {
   ImmutableXConfiguration,
   ERC20Withdrawal,
-  TokenType,
 } from '../../types';
 import {
   getSignableRegistrationOnchain,
@@ -68,7 +67,7 @@ export async function completeERC20WithdrawalWorfklow(
 ) {
   const assetType = await getEncodeAssetInfo(
     'asset',
-    TokenType.ERC20,
+    'ERC20',
     encodingApi,
     {
       token_id: token.data.tokenId,

--- a/src/workflows/withdrawal/completeERC721Withdrawal.ts
+++ b/src/workflows/withdrawal/completeERC721Withdrawal.ts
@@ -7,10 +7,7 @@ import {
   Registration__factory,
 } from '../../contracts';
 import * as encUtils from 'enc-utils';
-import {
-  ImmutableXConfiguration,
-  ERC721Withdrawal,
-} from '../../types';
+import { ImmutableXConfiguration, ERC721Withdrawal } from '../../types';
 import { getEncodeAssetInfo } from './getEncodeAssetInfo';
 import {
   getSignableRegistrationOnchain,
@@ -183,15 +180,10 @@ async function completeERC721Withdrawal(
   usersApi: UsersApi,
   config: ImmutableXConfiguration,
 ) {
-  const assetType = await getEncodeAssetInfo(
-    'asset',
-    'ERC721',
-    encodingApi,
-    {
-      token_id: token.data.tokenId,
-      token_address: token.data.tokenAddress,
-    },
-  );
+  const assetType = await getEncodeAssetInfo('asset', 'ERC721', encodingApi, {
+    token_id: token.data.tokenId,
+    token_address: token.data.tokenAddress,
+  });
 
   const coreContract = Core__factory.connect(
     config.ethConfiguration.coreContractAddress,

--- a/src/workflows/withdrawal/completeERC721Withdrawal.ts
+++ b/src/workflows/withdrawal/completeERC721Withdrawal.ts
@@ -10,7 +10,6 @@ import * as encUtils from 'enc-utils';
 import {
   ImmutableXConfiguration,
   ERC721Withdrawal,
-  TokenType,
 } from '../../types';
 import { getEncodeAssetInfo } from './getEncodeAssetInfo';
 import {
@@ -20,7 +19,7 @@ import {
 import { TransactionResponse } from '@ethersproject/providers';
 
 interface MintableERC721Withdrawal {
-  type: TokenType.ERC721;
+  type: 'ERC721';
   data: {
     id: string;
     blueprint?: string;
@@ -88,7 +87,7 @@ async function completeMintableERC721Withdrawal(
 ) {
   const assetType = await getEncodeAssetInfo(
     'mintable-asset',
-    TokenType.ERC721,
+    'ERC721',
     encodingApi,
     {
       id: token.data.id,
@@ -186,7 +185,7 @@ async function completeERC721Withdrawal(
 ) {
   const assetType = await getEncodeAssetInfo(
     'asset',
-    TokenType.ERC721,
+    'ERC721',
     encodingApi,
     {
       token_id: token.data.tokenId,
@@ -250,7 +249,7 @@ export async function completeERC721WithdrawalWorkflow(
         signer,
         starkPublicKey,
         {
-          type: TokenType.ERC721,
+          type: 'ERC721',
           data: {
             id: tokenId,
             tokenAddress: tokenAddress,

--- a/src/workflows/workflows.ts
+++ b/src/workflows/workflows.ts
@@ -21,7 +21,6 @@ import {
   ERC721Deposit,
   ETHDeposit,
   TokenDeposit,
-  TokenType,
   ImmutableXConfiguration,
   ERC721Withdrawal,
   ERC20Withdrawal,
@@ -130,11 +129,11 @@ export class Workflows {
 
   public async deposit(signer: Signer, deposit: TokenDeposit) {
     switch (deposit.type) {
-      case TokenType.ETH:
+      case 'ETH':
         return this.depositEth(signer, deposit);
-      case TokenType.ERC20:
+      case 'ERC20':
         return this.depositERC20(signer, deposit);
-      case TokenType.ERC721:
+      case 'ERC721':
         return this.depositERC721(signer, deposit);
     }
   }
@@ -198,11 +197,11 @@ export class Workflows {
     token: TokenWithdrawal,
   ) {
     switch (token.type) {
-      case TokenType.ETH:
+      case 'ETH':
         return this.completeEthWithdrawal(signer, starkPublicKey);
-      case TokenType.ERC20:
+      case 'ERC20':
         return this.completeERC20Withdrawal(signer, starkPublicKey, token);
-      case TokenType.ERC721:
+      case 'ERC721':
         return this.completeERC721Withdrawal(signer, starkPublicKey, token);
     }
   }


### PR DESCRIPTION

# Summary

this allows consumer to avoid having to import TokenType enum

[DX-1159]



# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


[DX-1159]: https://immutable.atlassian.net/browse/DX-1159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ