### PR TITLE
fix(isRegisteredOnchain): handle USER_UNREGISTERED

### DIFF
--- a/src/workflows/registration.ts
+++ b/src/workflows/registration.ts
@@ -57,11 +57,22 @@ export async function registerOffchainWorkflow({
   return;
 }
 
+interface IsRegisteredCheckError {
+  reason: string;
+}
+
 export async function isRegisteredOnChainWorkflow(
   starkPublicKey: string,
   contract: Registration,
 ): Promise<boolean> {
-  return await contract.isRegistered(starkPublicKey);
+  try {
+    return await contract.isRegistered(starkPublicKey);
+  } catch (ex) {
+    if ((ex as IsRegisteredCheckError).reason === 'USER_UNREGISTERED') {
+      return false;
+    }
+    throw ex;
+  }
 }
 
 export async function getSignableRegistrationOnchain(


### PR DESCRIPTION
# Summary
Registration contract isRegistered method may throw `error.reason = 'USER_UNREGISTERED'`
Updated to catch errors where reason is USER_UNREGISTERED to return false.
For all other errors, throw exception.

This issue was causing exceptions for registerAndDeposit/Withdraw methods when using unregistered(onchain) users.



# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->
