### PR TITLE
[DX-1227] Update Makefile, use sandbox OpenAPI spec.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: generate-openapi-prod
 generate-openapi-prod: get-openapi-prod generate-api
 
-.PHONY: generate-openapi-ropsten
-generate-openapi-ropsten: get-openapi-ropsten generate-api
+.PHONY: generate-openapi-sandbox
+generate-openapi-sandbox: get-openapi-sandbox generate-api
 
 .PHONY: get-openapi-prod
 get-openapi-prod:
@@ -11,11 +11,11 @@ get-openapi-prod:
     https://api.x.immutable.com/openapi \
     -o openapi.json
 
-.PHONY: get-openapi-ropsten
-get-openapi-ropsten:
+.PHONY: get-openapi-sandbox
+get-openapi-sandbox:
 	rm openapi.json && touch openapi.json && \
 	curl -H "Accept: application/json+v3" \
-    https://api.ropsten.x.immutable.com/openapi \
+    https://api.sandbox.x.immutable.com/openapi \
     -o openapi.json
 
 .PHONY: generate-api


### PR DESCRIPTION
# Summary

Configure the Makefile to work with the new Sandbox OpenAPI spec, which should generate the SDK with new base URLs too.

# Why the changes

Ropsten spec should be deprecated soon.


# Things worth calling out

Code generation was not run with this PR. The diff would be very large filled with auto-generated code.
