### PR TITLE
[DX-1237] Remove Utils namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * as Contracts from './exportContracts';
-export * as Utils from './exportUtils';
+export * from './exportUtils';
 export * from './types';
 export * from './api';
 export { Config } from './config';


### PR DESCRIPTION
# Summary
This PR removes the `Utils` namespace.


# Why the changes
Not required as their are only a few methods.


# Things worth calling out
Not used in any workflows or tests.
