### PR TITLE
Clarify token ids a bit further to remove ambiguity

### DIFF
--- a/src/api/models/mint-token-data-v2.ts
+++ b/src/api/models/mint-token-data-v2.ts
@@ -29,6 +29,7 @@ export interface MintTokenDataV2 {
     'blueprint'?: string;
     /**
      * Token ID
+     * Note: While the Token ID is required to be a string, it still needs to be a valid uint256 as per the ERC-721 token standard.
      * @type {string}
      * @memberof MintTokenDataV2
      */


### PR DESCRIPTION
# Summary

Although the [mintTokens API reference](https://docs.x.immutable.com/reference#/operations/mintTokens) requires token ids to be of string data type, token ids still need to conform to ERC-721 token standard i.e they need to be of uint256 data type.

Clarifying this in the docs will subjectively improve the developer experience.

# Why the changes

This will prevent developers from shooting themselves on the foot e.g specifying token ids with leading zeroes will still mint a token for them but withdrawing the said token to L1 and then depositing back to L2 could lead to discrepancies.


# Things worth calling out

- API will still throw meaningful error messages but this helps future devs to avoid pitfalls.
