### PR TITLE
export signRaw

### DIFF
--- a/src/exportUtils.ts
+++ b/src/exportUtils.ts
@@ -1,1 +1,1 @@
-export { generateStarkPrivateKey, createStarkSigner } from './utils';
+export { generateStarkPrivateKey, createStarkSigner, signRaw } from './utils';


### PR DESCRIPTION
# Summary
export `signRaw`

# Why the changes
Generating the x-imx-signature header requires following the signature format produced by `signRaw`. The IMX docs [here](https://docs.x.immutable.com/docs/generate-imx-signature/) mention using signRaw, but it does not seem to be exported for use yet.
