### PR TITLE
DX-1347: fix register and deposit nft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - formatError to handle undefined error.response.data
+- Deposit NFT flow workaround for broken registerAndDepositNft method
 
 ## [1.0.0-beta.3] - 2022-10-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - formatError to handle undefined error.response.data
-- Deposit NFT flow workaround for broken registerAndDepositNft method
+- Deposit workflow for register and deposit NFT
 
 ## [1.0.0-beta.3] - 2022-10-18
 


### PR DESCRIPTION
# Summary
Proxy registration contract method `registerAndDepositNft` currently fails ownership check in erc721 transfer method.
This workaround performs the register and deposit method calls separately.

[DX-1347]


# Before merging
- [x] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - `N/A`

[DX-1347]: https://immutable.atlassian.net/browse/DX-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ