### PR TITLE
[DX-1653] fix: :bug: Ensure grindKey works when keySeed has leading zeroes

### DIFF
--- a/src/utils/stark/starkCurve.test.ts
+++ b/src/utils/stark/starkCurve.test.ts
@@ -29,9 +29,27 @@ describe('Key grinding', () => {
       '86F3E7293141F20A8BAFF320E8EE4ACCB9D4A4BF2B4D295E8CEE784DB46E0519',
       16,
     );
-
     expect(grindKey(privateKey, starkEcOrder)).toEqual(
       '5c8c8683596c732541a59e03007b2d30dbbbb873556fe65b5fb63c16688f941',
+    );
+  });
+  it('should produce the correct ground key when the key starts with zero', () => {
+    const privateKey = new BN(
+      '086F3E7293141F20A8BAFF320E8EE4ACCB9D4A4BF2B4D295E8CEE784DB46E051',
+      16,
+    );
+    expect(grindKey(privateKey, starkEcOrder)).toEqual(
+      '2b2c6db790a95ce05426c3d67247547f1a72d104fd5af24553d42b7557ab082',
+    );
+  });
+  it('should produce the correct ground key when the hex key is less than 64 chars', () => {
+    const privateKey = new BN(
+      //same as previous test, but without the leading zero
+      '86F3E7293141F20A8BAFF320E8EE4ACCB9D4A4BF2B4D295E8CEE784DB46E051',
+      16,
+    );
+    expect(grindKey(privateKey, starkEcOrder)).toEqual(
+      '2b2c6db790a95ce05426c3d67247547f1a72d104fd5af24553d42b7557ab082',
     );
   });
 });

--- a/src/utils/stark/starkCurve.ts
+++ b/src/utils/stark/starkCurve.ts
@@ -92,7 +92,10 @@ export function grindKey(keySeed: BN, keyValLimit: BN) {
   const maxAllowedVal = sha256EcMaxDigest.sub(
     sha256EcMaxDigest.mod(keyValLimit),
   );
-  let key = hashKeyWithIndex(keySeed.toString('hex'), 0);
+  // The key passed to hashKeyWithIndex must have a length of 64 characters
+  // to ensure that the correct number of leading zeroes are used as input
+  // to the hashing loop
+  let key = hashKeyWithIndex(keySeed.toString('hex', 64), 0);
   // Make sure the produced key is devided by the Stark EC order, and falls within the range
   // [0, maxAllowedVal).
   for (let i = 1; key.gte(maxAllowedVal); i++) {


### PR DESCRIPTION
# Summary
This is a fix for DX-1653, where grinding a key with a leading zero produces an incorrect result


# Why the changes
These changes make the behaviour of grindKey consistent with [immutable/imx-sdk-js](https://github.com/immutable/imx-sdk-js) and [immutable/imx-core-sdk-golang](https://github.com/immutable/imx-core-sdk-golang)


# Things worth calling out
The same problem would occur if the keySeed contained more than one leading zero, so I fixed it for that case too.

# Before merging
- [ ] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`): `N/A`

