### PR TITLE
Add warning section to README to tell users to upgrade to v1.0.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![npm version](https://badge.fury.io/js/@imtbl%2Fcore-sdk.svg)](https://www.npmjs.com/package/@imtbl/core-sdk) [![Maintainability](https://api.codeclimate.com/v1/badges/219466ee5269620167e5/maintainability)](https://codeclimate.com/repos/62848fd8d4420d01b6002210/maintainability)
 
-> **⚠ DANGER: We recommend you upgrade to Core SDK v1.0.1 as soon as you can.**  
+> **⚠ We recommend you upgrade to Core SDK v1.0.1 as soon as you can.**  
 > We've released a critical bug fix in the stark `grindkey` method logic to work when there is a leading zero in the Ethereum wallet private key.
 
 The Immutable Core SDK provides convenient access to Immutable's APIs and smart contracts to help projects build better web3 games and marketplaces.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 
 [![npm version](https://badge.fury.io/js/@imtbl%2Fcore-sdk.svg)](https://www.npmjs.com/package/@imtbl/core-sdk) [![Maintainability](https://api.codeclimate.com/v1/badges/219466ee5269620167e5/maintainability)](https://codeclimate.com/repos/62848fd8d4420d01b6002210/maintainability)
 
+> **⚠ DANGER: We recommend you upgrade to Core SDK v1.0.1 as soon as you can.**  
+> We've released a critical bug fix in the stark `grindkey` method logic to work when there is a leading zero in the Ethereum wallet private key.
+
 The Immutable Core SDK provides convenient access to Immutable's APIs and smart contracts to help projects build better web3 games and marketplaces.
 
 Currently, our SDK supports interactions with our application-specific rollup based on StarkWare's StarkEx. In future, we'll be adding StarkNet support across our platform.


### PR DESCRIPTION
# Summary

v1.0.1 has a critical fix for the `grindkey` function. All users should upgrade as soon as possible.

https://immutable.atlassian.net/browse/DX-1708

# Why the changes

Critical bug fix was found and patched.

# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

# Before merging
- [ ] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] *Add documentation update 1*
    - [ ] *Add documentation update 2*
