### PR TITLE
[DX-2019] Add `sdkVersion` param to config

### DIFF
--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -34,6 +34,7 @@ describe('createConfig', () => {
     const chainID = 3;
     const customHeaders = {
       'x-custom-headers': 'x values',
+      'x-sdk-version': 'this should get overwritten',
     };
     const expected: ImmutableXConfiguration = {
       apiConfiguration: new Configuration({
@@ -68,6 +69,7 @@ describe('createConfig', () => {
     const chainID = 3;
     const customHeaders = {
       'x-custom-headers': 'x values',
+      'x-sdk-version': 'this should get overwritten',
     };
     const expected: ImmutableXConfiguration = {
       apiConfiguration: new Configuration({

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -92,7 +92,7 @@ describe('createConfig', () => {
       chainID,
       basePath,
       headers: customHeaders,
-      sdkIdentifier: sdkIdentifier,
+      sdkVersion: sdkIdentifier,
     });
     expect(actual).toEqual(expected);
   });

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -59,8 +59,8 @@ describe('createConfig', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('config should return optional sdkIdentifier thats provided', () => {
-    const sdkIdentifier = `imx-core-sdk-ts-test-1.0.0`;
+  it('config should return sdkVersion thats provided', () => {
+    const sdkVersion = `imx-core-sdk-ts-test-1.0.0`;
 
     const basePath = 'https://api.sandbox.x.immutable.com';
     const coreContractAddress = '0x1';
@@ -75,7 +75,7 @@ describe('createConfig', () => {
         baseOptions: {
           headers: {
             'x-custom-headers': 'x values',
-            'x-sdk-version': sdkIdentifier,
+            'x-sdk-version': sdkVersion,
           },
         },
       }),
@@ -92,7 +92,7 @@ describe('createConfig', () => {
       chainID,
       basePath,
       headers: customHeaders,
-      sdkVersion: sdkIdentifier,
+      sdkVersion: sdkVersion,
     });
     expect(actual).toEqual(expected);
   });

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -34,7 +34,6 @@ describe('createConfig', () => {
     const chainID = 3;
     const customHeaders = {
       'x-custom-headers': 'x values',
-      'x-sdk-version': 'this should get overwritten',
     };
     const expected: ImmutableXConfiguration = {
       apiConfiguration: new Configuration({
@@ -56,6 +55,44 @@ describe('createConfig', () => {
       chainID,
       basePath,
       headers: customHeaders,
+    });
+    expect(actual).toEqual(expected);
+  });
+
+  it('config should return optional sdkIdentifier thats provided', () => {
+    const sdkIdentifier = `imx-core-sdk-ts-test-1.0.0`;
+
+    const basePath = 'https://api.sandbox.x.immutable.com';
+    const coreContractAddress = '0x1';
+    const registrationContractAddress = '0x2';
+    const chainID = 3;
+    const customHeaders = {
+      'x-custom-headers': 'x values',
+    };
+    const expected: ImmutableXConfiguration = {
+      apiConfiguration: new Configuration({
+        basePath,
+        baseOptions: {
+          headers: {
+            'x-custom-headers': 'x values',
+            'x-sdk-version': sdkIdentifier,
+          },
+        },
+      }),
+      ethConfiguration: {
+        chainID,
+        coreContractAddress,
+        registrationContractAddress,
+      },
+    };
+
+    const actual = Config.createConfig({
+      coreContractAddress,
+      registrationContractAddress,
+      chainID,
+      basePath,
+      headers: customHeaders,
+      sdkIdentifier: sdkIdentifier,
     });
     expect(actual).toEqual(expected);
   });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -4,7 +4,7 @@ import {
 } from '../api';
 import { version } from '../../package.json';
 
-const defaultHeaders = { 'x-sdk-version': `imx-core-sdk-ts-${version}` };
+const coreSDKIdentifier = `imx-core-sdk-ts-${version}`;
 
 /**
  * The configuration for the Ethereum network
@@ -32,6 +32,7 @@ export interface ImmutableXConfiguration {
 interface Environment extends EthConfiguration {
   basePath: string;
   headers?: Record<string, string>;
+  sdkIdentifier?: string;
 }
 
 const createConfig = ({
@@ -40,12 +41,13 @@ const createConfig = ({
   chainID,
   basePath,
   headers,
+  sdkIdentifier = coreSDKIdentifier,
 }: Environment): ImmutableXConfiguration => {
   if (!basePath.trim()) {
     throw Error('basePath can not be empty');
   }
 
-  headers = { ...(headers || {}), ...defaultHeaders };
+  headers = { ...(headers || {}), ...{ 'x-sdk-version': sdkIdentifier } };
   const apiConfigOptions: ConfigurationParameters = {
     basePath,
     baseOptions: { headers },

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -4,7 +4,7 @@ import {
 } from '../api';
 import { version } from '../../package.json';
 
-const coreSDKIdentifier = `imx-core-sdk-ts-${version}`;
+const defaultHeaders = { 'x-sdk-version': `imx-core-sdk-ts-${version}` };
 
 /**
  * The configuration for the Ethereum network
@@ -32,7 +32,7 @@ export interface ImmutableXConfiguration {
 interface Environment extends EthConfiguration {
   basePath: string;
   headers?: Record<string, string>;
-  sdkIdentifier?: string;
+  sdkVersion?: string;
 }
 
 const createConfig = ({
@@ -41,13 +41,17 @@ const createConfig = ({
   chainID,
   basePath,
   headers,
-  sdkIdentifier = coreSDKIdentifier,
+  sdkVersion,
 }: Environment): ImmutableXConfiguration => {
   if (!basePath.trim()) {
     throw Error('basePath can not be empty');
   }
 
-  headers = { ...(headers || {}), ...{ 'x-sdk-version': sdkIdentifier } };
+  if (sdkVersion) {
+    defaultHeaders['x-sdk-version'] = sdkVersion;
+  }
+
+  headers = { ...(headers || {}), ...defaultHeaders };
   const apiConfigOptions: ConfigurationParameters = {
     basePath,
     baseOptions: { headers },


### PR DESCRIPTION
# Summary
This is a **non breaking change** as we default to the Core SDK identifier for this change. It will not affect existing configs.


# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

# Before merging
- [ ] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] *Add documentation update 1*
    - [ ] *Add documentation update 2*
