### PR TITLE
TD-503 Revert version number in package.json and CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.3] - 2023-07-28
+## [Unreleased] - 2023-07-28
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imtbl/core-sdk",
-  "version": "2.0.3",
+  "version": "2.0.2",
   "description": "Immutable Core SDK",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
The version numbers in both package.json and CHANGELOG.md were mistakenly updated to 2.0.3. This commit reverts the version back to 2.0.2 in package.json, and changes the version title in the CHANGELOG.md to "Unreleased". The updates made were premature and the version number should only be changed upon official release.

# Summary
<!--- A short summary about what this PR is doing. -->


# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

# Before merging
- [ ] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] *Add documentation update 1*
    - [ ] *Add documentation update 2*
