### PR TITLE
TD-803 Update version to 2.1.0 in changelog and package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2023-07-28
+## [2.1.0] - 2023-07-28
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imtbl/core-sdk",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Immutable Core SDK",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
This commit changes the version of the project from 2.0.2 to 2.1.0 in both the package.json and the CHANGELOG.md files. The 'unreleased' tag in the changelog is also updated to reflect the new version. This change is made to mark the completion of new features and enhancements for the 2.1.0 release.

# Summary
<!--- A short summary about what this PR is doing. -->


# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

# Before merging
- [ ] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] *Add documentation update 1*
    - [ ] *Add documentation update 2*
