### PR TITLE
feat: TD-917 reroute getTrade to getTradeV3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Rerouted getTrade to v3 endpoint
+
 ## [2.1.0] - 2023-07-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.0] - 2023-09-12
 - Rerouted getTrade to v3 endpoint
 
 ## [2.1.0] - 2023-07-28

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imtbl/core-sdk",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Immutable Core SDK",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/src/ImmutableX.ts
+++ b/src/ImmutableX.ts
@@ -724,7 +724,7 @@ export class ImmutableX {
    */
   public getTrade(request: TradesApiGetTradeRequest) {
     return this.tradesApi
-      .getTrade(request)
+      .getTradeV3(request)
       .then(res => res.data)
       .catch(err => {
         throw formatError(err);


### PR DESCRIPTION
# Summary
Rerouting sunsetted v1s to v3 last endpoint left out was getTrade (workflow)


# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

# Before merging
- [ ] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] *Add documentation update 1*
    - [ ] *Add documentation update 2*
