### PR TITLE
Typo fix README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -335,7 +335,7 @@ yarn get-withdrawal
 ```
 ## List withdrawal
 
-Update [lisWithdrawals.ts](./listWithdrawals.ts#L10) the desired field and then run
+Update [listWithdrawals.ts](./listWithdrawals.ts#L10) the desired field and then run
 
 ```sh
 yarn list-withdrawals


### PR DESCRIPTION
Hello,

In the section "List withdrawal," there's a typo in the command title "Update lisWithdrawals.ts the desired field and then run." It should be "listWithdrawals.ts" instead of "lisWithdrawals.ts".

# Summary
<!--- A short summary about what this PR is doing. -->


# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

# Before merging
- [ ] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] *Add documentation update 1*
    - [ ] *Add documentation update 2*
