### PR TITLE
CORE-2033 Add Withdraw All workflows for registered user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2024-02-27
+
+### Added
+
+- `completeWithdrawal` now supports v3 and v4 withdrawal flow for registered users.
+
 ## [3.2.0] - 2024-02-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imtbl/core-sdk",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Immutable Core SDK",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/src/workflows/withdrawal/completeERC20Withdrawal.ts
+++ b/src/workflows/withdrawal/completeERC20Withdrawal.ts
@@ -5,9 +5,10 @@ import { ImmutableXConfiguration } from '../../config';
 import {
   Core,
   Core__factory,
+  CoreV4__factory,
   Registration,
   Registration__factory,
-  CoreV4__factory,
+  RegistrationV4__factory,
 } from '../../contracts';
 import { ERC20Token } from '../../types';
 import {
@@ -122,6 +123,33 @@ export async function completeERC20WithdrawalV2Workflow(
     ownerKey,
     assetType.asset_type,
   );
+
+  return signer.sendTransaction(populatedTransaction);
+}
+
+export async function completeAllERC20WithdrawalWorkflow(
+  signer: Signer,
+  starkPublicKey: string,
+  token: ERC20Token,
+  encodingApi: EncodingApi,
+  config: ImmutableXConfiguration,
+): Promise<TransactionResponse> {
+  const assetType = await getEncodeAssetInfo('asset', 'ERC20', encodingApi, {
+    token_address: token.tokenAddress,
+  });
+
+  const registrationContract = RegistrationV4__factory.connect(
+    config.ethConfiguration.registrationContractAddress,
+    signer,
+  );
+
+  const ethAddress = await signer.getAddress();
+  const populatedTransaction =
+    await registrationContract.populateTransaction.withdrawAll(
+      ethAddress,
+      starkPublicKey,
+      assetType.asset_id,
+    );
 
   return signer.sendTransaction(populatedTransaction);
 }

--- a/src/workflows/withdrawal/completeEthWithdrawal.ts
+++ b/src/workflows/withdrawal/completeEthWithdrawal.ts
@@ -5,9 +5,10 @@ import { ImmutableXConfiguration } from '../../config';
 import {
   Core,
   Core__factory,
+  CoreV4__factory,
   Registration,
   Registration__factory,
-  CoreV4__factory,
+  RegistrationV4__factory,
 } from '../../contracts';
 import {
   getSignableRegistrationOnchain,
@@ -115,6 +116,30 @@ export async function completeEthWithdrawalV2Workflow(
     ownerKey,
     assetType.asset_type,
   );
+
+  return signer.sendTransaction(populatedTransaction);
+}
+
+export async function completeAllEthWithdrawalWorkflow(
+  signer: Signer,
+  starkPublicKey: string,
+  encodingApi: EncodingApi,
+  config: ImmutableXConfiguration,
+): Promise<TransactionResponse> {
+  const assetType = await getEncodeAssetInfo('asset', 'ETH', encodingApi);
+
+  const registrationContract = RegistrationV4__factory.connect(
+    config.ethConfiguration.registrationContractAddress,
+    signer,
+  );
+
+  const ethAddress = await signer.getAddress();
+  const populatedTransaction =
+    await registrationContract.populateTransaction.withdrawAll(
+      ethAddress,
+      starkPublicKey,
+      assetType.asset_id,
+    );
 
   return signer.sendTransaction(populatedTransaction);
 }

--- a/src/workflows/withdrawal/completeWithdrawal.ts
+++ b/src/workflows/withdrawal/completeWithdrawal.ts
@@ -1,13 +1,15 @@
 import { Signer } from '@ethersproject/abstract-signer';
 import { TransactionResponse } from '@ethersproject/providers';
 import { AnyToken } from 'src/types';
-import {
-  completeEthWithdrawalV1Workflow,
-  completeEthWithdrawalV2Workflow,
-} from './completeEthWithdrawal';
 import { EncodingApi, MintsApi, UsersApi } from 'src/api';
 import { ImmutableXConfiguration } from 'src/config';
 import {
+  completeAllEthWithdrawalWorkflow,
+  completeEthWithdrawalV1Workflow,
+  completeEthWithdrawalV2Workflow,
+} from './completeEthWithdrawal';
+import {
+  completeAllERC20WithdrawalWorkflow,
   completeERC20WithdrawalV1Workflow,
   completeERC20WithdrawalV2Workflow,
 } from './completeERC20Withdrawal';
@@ -78,6 +80,43 @@ export async function completeWithdrawalV2Workflow(
       return completeERC721WithdrawalV2Workflow(
         signer,
         ownerKey,
+        token,
+        encodingApi,
+        mintsApi,
+        config,
+      );
+  }
+}
+
+export async function completeAllWithdrawalWorkflow(
+  signer: Signer,
+  starkPublicKey: string,
+  token: AnyToken,
+  encodingApi: EncodingApi,
+  mintsApi: MintsApi,
+  config: ImmutableXConfiguration,
+): Promise<TransactionResponse> {
+  switch (token.type) {
+    case 'ETH':
+      return completeAllEthWithdrawalWorkflow(
+        signer,
+        starkPublicKey,
+        encodingApi,
+        config,
+      );
+    case 'ERC20':
+      return completeAllERC20WithdrawalWorkflow(
+        signer,
+        starkPublicKey,
+        token,
+        encodingApi,
+        config,
+      );
+    case 'ERC721':
+      // for ERC721, if the v3 balance > 0, then the v4 balance is 0
+      return completeERC721WithdrawalV2Workflow(
+        signer,
+        starkPublicKey,
         token,
         encodingApi,
         mintsApi,

--- a/src/workflows/withdrawal/getWithdrawalBalance.ts
+++ b/src/workflows/withdrawal/getWithdrawalBalance.ts
@@ -1,0 +1,149 @@
+import { Signer } from '@ethersproject/abstract-signer';
+import { EncodingApi, MintsApi } from '../../api';
+import { ImmutableXConfiguration } from '../../config';
+import { CoreV4__factory } from '../../contracts';
+import { AnyToken, ERC721Token } from '../../types';
+import { getEncodeAssetInfo } from './getEncodeAssetInfo';
+import { BigNumber } from 'ethers';
+
+async function getWithdrawalBalance(
+  signer: Signer,
+  ownerKey: string,
+  assetId: string,
+  config: ImmutableXConfiguration,
+) {
+  const coreContract = CoreV4__factory.connect(
+    config.ethConfiguration.coreContractAddress,
+    signer,
+  );
+  return coreContract.getWithdrawalBalance(ownerKey, assetId);
+}
+
+async function getETHWithdrawalBalance(
+  signer: Signer,
+  ownerKey: string,
+  encodingApi: EncodingApi,
+  config: ImmutableXConfiguration,
+): Promise<BigNumber> {
+  const assetType = await getEncodeAssetInfo('asset', 'ETH', encodingApi);
+  return await getWithdrawalBalance(
+    signer,
+    ownerKey,
+    assetType.asset_id,
+    config,
+  );
+}
+
+async function getERC20WithdrawalBalance(
+  signer: Signer,
+  ownerKey: string,
+  tokenAddress: string,
+  encodingApi: EncodingApi,
+  config: ImmutableXConfiguration,
+): Promise<BigNumber> {
+  const assetType = await getEncodeAssetInfo('asset', 'ERC20', encodingApi, {
+    token_address: tokenAddress,
+  });
+  return await getWithdrawalBalance(
+    signer,
+    ownerKey,
+    assetType.asset_id,
+    config,
+  );
+}
+
+async function getERC721WithdrawalBalance(
+  signer: Signer,
+  ownerKey: string,
+  token: ERC721Token,
+  encodingApi: EncodingApi,
+  mintsApi: MintsApi,
+  config: ImmutableXConfiguration,
+): Promise<BigNumber> {
+  const tokenAddress = token.tokenAddress;
+  const tokenId = token.tokenId;
+  return await mintsApi
+    .getMintableTokenDetailsByClientTokenId({
+      tokenAddress,
+      tokenId,
+    })
+    .then(async mintableToken => {
+      const assetType = await getEncodeAssetInfo(
+        'mintable-asset',
+        'ERC721',
+        encodingApi,
+        {
+          id: tokenId,
+          token_address: tokenAddress,
+          ...(mintableToken.data.blueprint && {
+            blueprint: mintableToken.data.blueprint,
+          }),
+        },
+      );
+      return await getWithdrawalBalance(
+        signer,
+        ownerKey,
+        assetType.asset_id,
+        config,
+      );
+    })
+    .catch(async error => {
+      if (error.response?.status === 404) {
+        // token is not a mintable ERC721 token
+        const assetType = await getEncodeAssetInfo(
+          'asset',
+          'ERC721',
+          encodingApi,
+          {
+            token_id: token.tokenId,
+            token_address: token.tokenAddress,
+          },
+        );
+        return await getWithdrawalBalance(
+          signer,
+          ownerKey,
+          assetType.asset_id,
+          config,
+        );
+      }
+      throw error; // unable to recover from any other kind of error
+    });
+}
+
+export async function getWithdrawalBalanceWorkflow(
+  signer: Signer,
+  ownerKey: string,
+  token: AnyToken,
+  encodingApi: EncodingApi,
+  mintsApi: MintsApi,
+  config: ImmutableXConfiguration,
+): Promise<BigNumber> {
+  switch (token.type) {
+    case 'ETH':
+      return await getETHWithdrawalBalance(
+        signer,
+        ownerKey,
+        encodingApi,
+        config,
+      );
+    case 'ERC20':
+      return await getERC20WithdrawalBalance(
+        signer,
+        ownerKey,
+        token.tokenAddress,
+        encodingApi,
+        config,
+      );
+    case 'ERC721':
+      return await getERC721WithdrawalBalance(
+        signer,
+        ownerKey,
+        token,
+        encodingApi,
+        mintsApi,
+        config,
+      );
+    default:
+      throw new Error('Unsupported token type');
+  }
+}


### PR DESCRIPTION
# Summary

Given a registered user that has prepared v1 withdrawal and v2 withdrawal, add a function that can be used to withdraw both in one transaction

Test transaction: https://sepolia.etherscan.io/tx/0x51a34c0d3c9de42319b1dcb90d445a76c14d3e89e4f9ea9f4121f89dc3a06492#eventlog

# Why the changes
<!--- State the reason/context for the change. -->


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->

# Before merging
- [ ] ***For Immutable developers:*** Do the changes in this PR require documentation updates? Please refer to this [SDK documentation guide](https://immutable.atlassian.net/wiki/spaces/PPS/pages/1916994017/SDK+documentation+guide) and list links to documentation update PRs (they don't have to be merged) below (or write `N/A`):
    - [ ] *Add documentation update 1*
    - [ ] *Add documentation update 2*
